### PR TITLE
APK building workflows (on demand and CI one)

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -50,15 +50,15 @@ jobs:
           RELEASE_KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PW }}
           RELEASE_KEYSTORE_ALIAS: ${{ secrets.KEYSTORE_ALIAS }}
           RELEASE_KEY_PASSWORD: ${{ secrets.KEY_PW }}
-        run: ./gradlew assembleRelease --stacktrace
+        run: ./gradlew assembleRelease --info --stacktrace
 
-      - name: Build Release APK
+      - name: Build Debug APK
         env:
           ENCODED_STRING: ${{ secrets.KEYSTORE }}
           RELEASE_KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PW }}
           RELEASE_KEYSTORE_ALIAS: ${{ secrets.KEYSTORE_ALIAS }}
           RELEASE_KEY_PASSWORD: ${{ secrets.KEY_PW }}
-        run: ./gradlew assembleDebug --stacktrace
+        run: ./gradlew assembleDebug --info --stacktrace
 
       - name: Generate SPDX
         env:

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -73,8 +73,8 @@ jobs:
         run: | 
           echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
           mkdir upload
-          mv app/build/outputs/apk/debug/app-debug.apk ./upload/omnt-debug.apk
-          mv app/build/outputs/apk/release/app-release.apk ./upload/omnt-release.apk
+          mv app/build/outputs/apk/debug/*debug*.apk ./upload/omnt-debug.apk
+          mv app/build/outputs/apk/release/*release*.apk ./upload/omnt-release.apk
           mv app/build/spdx/release.spdx.json ./upload/release.spdx.json
 
       - name: Upload All Artifacts

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -73,8 +73,8 @@ jobs:
         run: | 
           echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
           mkdir upload
-          mv app/build/outputs/apk/debug/*debug*.apk ./upload/omnt-debug.apk
-          mv app/build/outputs/apk/release/*release*.apk ./upload/omnt-release.apk
+          mv app/build/outputs/apk/debug/*debug*.apk ./upload
+          mv app/build/outputs/apk/release/*release*.apk ./upload
           mv app/build/spdx/release.spdx.json ./upload/release.spdx.json
 
       - name: Upload All Artifacts

--- a/.github/workflows/build-apk.yaml
+++ b/.github/workflows/build-apk.yaml
@@ -32,11 +32,22 @@ jobs:
 
       - name: Build APK
         working-directory: ./workspace
+        env:
+          GRADLE_OPTS: "-Dorg.gradle.daemon=false -Dorg.gradle.workers.max=2"
         run: |
           if [ ! -f "gradlew" ]; then gradle wrapper; fi
           chmod +x gradlew
-          ./gradlew ${{ github.event.inputs.taskName }} --stacktrace
+          ./gradlew ${{ github.event.inputs.taskName }} --stacktrace --scan || exit 1
 
+      - name: Cache Gradle packages
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
       - name: Upload the APK artifact with 1 day retention
         id: upload-apk
         if: ${{ success() }}

--- a/.github/workflows/build-apk.yaml
+++ b/.github/workflows/build-apk.yaml
@@ -38,8 +38,15 @@ jobs:
           ./gradlew ${{ github.event.inputs.taskName }} --stacktrace
 
       - name: Upload the APK artifact with 1 day retention
+        id: upload-apk
+        if: ${{ success() }}
         uses: actions/upload-artifact@v4
         with:
           path: ./**/*.apk
           name: apk-archive
           retention-days: 1
+          if-no-files-found: error
+
+      - name: Verify APK upload
+        if: ${{ success() && steps.upload-apk.outcome == 'success' }}
+        run: echo "✅ APK built and uploaded successfully"

--- a/.github/workflows/build-apk.yaml
+++ b/.github/workflows/build-apk.yaml
@@ -7,7 +7,7 @@ on:
       repository:
         description: "Git repository URL"
         required: true
-        default: "https://github.com/android/sunflower"
+        default: "https://github.com/Cloud-City-RS/OMNTelcoMetrics"
       jdkVersion:
         description: "OpenJDK version to use: 8 / 11 / 17 etc."
         required: false

--- a/.github/workflows/build-apk.yaml
+++ b/.github/workflows/build-apk.yaml
@@ -1,0 +1,45 @@
+name: Build Android APK
+run-name: ${{ github.event.inputs.repository }}:${{ github.event.inputs.taskName }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      repository:
+        description: "Git repository URL"
+        required: true
+        default: "https://github.com/android/sunflower"
+      jdkVersion:
+        description: "OpenJDK version to use: 8 / 11 / 17 etc."
+        required: false
+        default: "17"
+      taskName:
+        description: "build.gradle task name: assemble[Flavor]Debug"
+        required: false
+        default: "assembleDebug"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest # Android SDK is built-in in this image
+    steps:
+      - name: Setup JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: "temurin"
+          java-version: ${{ github.event.inputs.jdkVersion }}
+
+      - name: Clone project
+        run: git clone --recurse-submodules --depth=1 ${{ github.event.inputs.repository }} workspace
+
+      - name: Build APK
+        working-directory: ./workspace
+        run: |
+          if [ ! -f "gradlew" ]; then gradle wrapper; fi
+          chmod +x gradlew
+          ./gradlew ${{ github.event.inputs.taskName }} --stacktrace
+
+      - name: Upload the APK artifact with 1 day retention
+        uses: actions/upload-artifact@v4
+        with:
+          path: ./**/*.apk
+          name: apk-archive
+          retention-days: 1


### PR DESCRIPTION
Fix CI workflow so that it can properly build APKs after every commit.

Additionally, add one more workflow which can build any repo/branch without forking them.

Both of them upload the built APK when done; only the CI one is set to run

Issue link: https://github.com/Cloud-City-RS/OMNTelcoMetrics/issues/3

If we revisit this later on, the new key has to be generated by using the `keytool` tool, and then Base64'd and that has to be put in the Repo's Secrets as `KEYSTORE`, the key alias as `KEYALIAS` and the store/key passwords as `STOREPASSWORD` and `KEYPASSWORD` respectively.

The command for generating the new keystore is:
```
keytool -genkeypair -v -keystore new-keystore.jks -keyalg RSA -keysize 2048 -validity 10000 -alias cloudcity
```
and that will generate a  keystore with 'cloudcity' key alias

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new workflow for manually building Android APKs with customizable inputs.
	- Updated existing workflow to focus on building debug APKs, enhancing output detail during the process.
  
- **Bug Fixes**
	- Improved file handling in APK build processes to accommodate variations in file names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->