### PR TITLE
Fix some build problems

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -50,15 +50,15 @@ jobs:
           RELEASE_KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PW }}
           RELEASE_KEYSTORE_ALIAS: ${{ secrets.KEYSTORE_ALIAS }}
           RELEASE_KEY_PASSWORD: ${{ secrets.KEY_PW }}
-        run: ./gradlew assembleRelease --stacktrace
+        run: ./gradlew assembleRelease --info --stacktrace
 
-      - name: Build Release APK
+      - name: Build Debug APK
         env:
           ENCODED_STRING: ${{ secrets.KEYSTORE }}
           RELEASE_KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PW }}
           RELEASE_KEYSTORE_ALIAS: ${{ secrets.KEYSTORE_ALIAS }}
           RELEASE_KEY_PASSWORD: ${{ secrets.KEY_PW }}
-        run: ./gradlew assembleDebug --stacktrace
+        run: ./gradlew assembleDebug --info --stacktrace
 
       - name: Generate SPDX
         env:

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -73,8 +73,8 @@ jobs:
         run: | 
           echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
           mkdir upload
-          mv app/build/outputs/apk/debug/app-debug.apk ./upload/omnt-debug.apk
-          mv app/build/outputs/apk/release/app-release.apk ./upload/omnt-release.apk
+          mv app/build/outputs/apk/debug/*debug*.apk ./upload/omnt-debug.apk
+          mv app/build/outputs/apk/release/*release*.apk ./upload/omnt-release.apk
           mv app/build/spdx/release.spdx.json ./upload/release.spdx.json
 
       - name: Upload All Artifacts

--- a/.github/workflows/build-apk.yaml
+++ b/.github/workflows/build-apk.yaml
@@ -1,0 +1,45 @@
+name: Build Android APK
+run-name: ${{ github.event.inputs.repository }}:${{ github.event.inputs.taskName }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      repository:
+        description: "Git repository URL"
+        required: true
+        default: "https://github.com/android/sunflower"
+      jdkVersion:
+        description: "OpenJDK version to use: 8 / 11 / 17 etc."
+        required: false
+        default: "17"
+      taskName:
+        description: "build.gradle task name: assemble[Flavor]Debug"
+        required: false
+        default: "assembleDebug"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest # Android SDK is built-in in this image
+    steps:
+      - name: Setup JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: "temurin"
+          java-version: ${{ github.event.inputs.jdkVersion }}
+
+      - name: Clone project
+        run: git clone --recurse-submodules --depth=1 ${{ github.event.inputs.repository }} workspace
+
+      - name: Build APK
+        working-directory: ./workspace
+        run: |
+          if [ ! -f "gradlew" ]; then gradle wrapper; fi
+          chmod +x gradlew
+          ./gradlew ${{ github.event.inputs.taskName }} --stacktrace
+
+      - name: Upload the APK artifact with 1 day retention
+        uses: actions/upload-artifact@v4
+        with:
+          path: ./**/*.apk
+          name: apk-archive
+          retention-days: 1

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -99,6 +99,9 @@ android {
         abortOnError false
     }
 
+    /**
+     * NOTE: if changing this, make sure to update the expected filename in the android.yml workflow!
+     */
     applicationVariants.configureEach { variant ->
         variant.outputs.configureEach {
 //            outputFileName = "CloudCity_OpenMobileNetworkToolkit_${variant.buildType.name}_${defaultConfig.versionName}_${getGitHash()}.apk"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -24,14 +24,18 @@ if (keystorePropertiesFile.exists()) {
     keystoreProperties['storePassword'] = "omnt2024"
 }
 
-def getGitHash = { ->
-    def stdout = new ByteArrayOutputStream()
-    exec {
-        commandLine "git", "rev-parse", "--short", "HEAD"
-        standardOutput = stdout
-    }
-    return stdout.toString().trim()
-}
+/**
+ * Commented out because this just can't find 'git' on my machine even though everything else can run it from the folder...
+ * Super unnecessary to have it in the filename, we'll make a better/different versioning scheme
+ */
+//def getGitHash = { ->
+//    def stdout = new ByteArrayOutputStream()
+//    exec {
+//        commandLine "git", "rev-parse", "--short", "HEAD"
+//        standardOutput = stdout
+//    }
+//    return stdout.toString().trim()
+//}
 
 android {
     signingConfigs {
@@ -57,7 +61,7 @@ android {
         targetSdk 34
         versionCode 3
         versionName "0.3"
-        resValue("string", "git_hash", getGitHash())
+//        resValue("string", "git_hash", getGitHash())
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         signingConfig signingConfigs.debug
@@ -97,7 +101,8 @@ android {
 
     applicationVariants.configureEach { variant ->
         variant.outputs.configureEach {
-            outputFileName = "CloudCity_OpenMobileNetworkToolkit_${variant.buildType.name}_${defaultConfig.versionName}_${getGitHash()}.apk"
+//            outputFileName = "CloudCity_OpenMobileNetworkToolkit_${variant.buildType.name}_${defaultConfig.versionName}_${getGitHash()}.apk"
+            outputFileName = "CloudCity_OpenMobileNetworkToolkit_${variant.buildType.name}_${defaultConfig.versionName}.apk"
         }
     }
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -24,19 +24,6 @@ if (keystorePropertiesFile.exists()) {
     keystoreProperties['storePassword'] = "omnt2024"
 }
 
-/**
- * Commented out because this just can't find 'git' on my machine even though everything else can run it from the folder...
- * Super unnecessary to have it in the filename, we'll make a better/different versioning scheme
- */
-//def getGitHash = { ->
-//    def stdout = new ByteArrayOutputStream()
-//    exec {
-//        commandLine "git", "rev-parse", "--short", "HEAD"
-//        standardOutput = stdout
-//    }
-//    return stdout.toString().trim()
-//}
-
 android {
     signingConfigs {
         debug {
@@ -61,7 +48,6 @@ android {
         targetSdk 34
         versionCode 3
         versionName "0.3"
-//        resValue("string", "git_hash", getGitHash())
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         signingConfig signingConfigs.debug
@@ -104,7 +90,6 @@ android {
      */
     applicationVariants.configureEach { variant ->
         variant.outputs.configureEach {
-//            outputFileName = "CloudCity_OpenMobileNetworkToolkit_${variant.buildType.name}_${defaultConfig.versionName}_${getGitHash()}.apk"
             outputFileName = "CloudCity_OpenMobileNetworkToolkit_${variant.buildType.name}_${defaultConfig.versionName}.apk"
         }
     }

--- a/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/AboutFragment.java
+++ b/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/AboutFragment.java
@@ -48,7 +48,7 @@ public class AboutFragment extends Fragment {
         about_text.append("\n\n");
         about_text.append("Version Code: " + BuildConfig.VERSION_CODE + "\nVersion Name: " + BuildConfig.VERSION_NAME + "\n");
         about_text.append("Build Type: " + BuildConfig.BUILD_TYPE + "\n");
-        about_text.append("GitHash: " + getString(R.string.git_hash) + "\n");
+//        about_text.append("GitHash: " + getString(R.string.git_hash) + "\n");
         about_text.append("SigningHash sha256: " +  GlobalVars.getInstance().getSigning_hash() + "\n");
     }
 }

--- a/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/AboutFragment.java
+++ b/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/AboutFragment.java
@@ -48,7 +48,6 @@ public class AboutFragment extends Fragment {
         about_text.append("\n\n");
         about_text.append("Version Code: " + BuildConfig.VERSION_CODE + "\nVersion Name: " + BuildConfig.VERSION_NAME + "\n");
         about_text.append("Build Type: " + BuildConfig.BUILD_TYPE + "\n");
-//        about_text.append("GitHash: " + getString(R.string.git_hash) + "\n");
         about_text.append("SigningHash sha256: " +  GlobalVars.getInstance().getSigning_hash() + "\n");
     }
 }


### PR DESCRIPTION
This PR is just about making gradle to stop using git directly, while it works fine for CI (and probably linux machines) it's just screwing with me on the windows machine. 

We'll either need to parametrize the path to git via some project.properties or just not use `git` from gradle.

While the PR looks bigger than it should be, the only two relevant commits are 65b8ce6 and dd67aaa both of which are kinda one-liners

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new workflow for building Android APKs, allowing manual triggers with customizable inputs.
  
- **Bug Fixes**
	- Removed the display of the Git hash in the About section of the app for a cleaner user experience.

- **Chores**
	- Updated APK naming convention to simplify output file names by excluding the Git hash.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->