### PR TITLE
Misc fixes to both fragments to make the app more stable

### DIFF
--- a/app/src/main/java/cloudcity/CloudCityConstants.java
+++ b/app/src/main/java/cloudcity/CloudCityConstants.java
@@ -12,4 +12,7 @@ public class CloudCityConstants {
      * Name of the cloud city token preference
      */
     public static final String CLOUD_CITY_TOKEN = "cloud_city_token";
+
+    public static final String CLOUD_CITY_GENERAL_LOGGING = "enable_logging";
+    public static final String CLOUD_CITY_CC_LOGGING = "enable_cloud_city";
 }

--- a/app/src/main/java/cloudcity/LoggingServiceExtensions.java
+++ b/app/src/main/java/cloudcity/LoggingServiceExtensions.java
@@ -60,6 +60,7 @@ public class LoggingServiceExtensions {
                 }
 
                 NetworkDataModel data = getCloudCityData();
+                Log.d(TAG, "getCloudCityData() returned "+data);
                 if (data == null) {
                     Log.e(TAG, "run: Error in getting data from Cloud city, skipping sending");
                     return;
@@ -76,6 +77,7 @@ public class LoggingServiceExtensions {
                     gv.getLog_status().setColorFilter(Color.argb(255, 255, 0, 0));
                 }
             } catch (Exception e) {
+                Log.e(TAG, "Exception happened! exception "+e, e);
                 throw new RuntimeException(e);
             }
 

--- a/app/src/main/java/cloudcity/LoggingServiceExtensions.java
+++ b/app/src/main/java/cloudcity/LoggingServiceExtensions.java
@@ -63,6 +63,7 @@ public class LoggingServiceExtensions {
                 Log.d(TAG, "getCloudCityData() returned "+data);
                 if (data == null) {
                     Log.e(TAG, "run: Error in getting data from Cloud city, skipping sending");
+                    CloudCityHandler.postDelayed(this, interval);
                     return;
                 }
                 NetworkDataModelRequest requestData = new NetworkDataModelRequest();

--- a/app/src/main/java/cloudcity/LoggingServiceExtensions.java
+++ b/app/src/main/java/cloudcity/LoggingServiceExtensions.java
@@ -63,19 +63,18 @@ public class LoggingServiceExtensions {
                 Log.d(TAG, "getCloudCityData() returned "+data);
                 if (data == null) {
                     Log.e(TAG, "run: Error in getting data from Cloud city, skipping sending");
-                    CloudCityHandler.postDelayed(this, interval);
-                    return;
-                }
-                NetworkDataModelRequest requestData = new NetworkDataModelRequest();
-                requestData.add(data);
+                } else {
+                    NetworkDataModelRequest requestData = new NetworkDataModelRequest();
+                    requestData.add(data);
 
-                boolean status = CloudCityHelpers.sendData(address, token, requestData);
+                    boolean status = CloudCityHelpers.sendData(address, token, requestData);
 
-                if (status) {
-                    /* Data sent successfully indicate in status icon. */
-                    gv.getLog_status().setColorFilter(Color.argb(255, 0, 255, 0));
-                } else  {
-                    gv.getLog_status().setColorFilter(Color.argb(255, 255, 0, 0));
+                    if (status) {
+                        /* Data sent successfully indicate in status icon. */
+                        gv.getLog_status().setColorFilter(Color.argb(255, 0, 255, 0));
+                    } else {
+                        gv.getLog_status().setColorFilter(Color.argb(255, 255, 0, 0));
+                    }
                 }
             } catch (Exception e) {
                 Log.e(TAG, "Exception happened! exception "+e, e);

--- a/app/src/main/java/cloudcity/LoggingServiceExtensions.java
+++ b/app/src/main/java/cloudcity/LoggingServiceExtensions.java
@@ -109,6 +109,9 @@ public class LoggingServiceExtensions {
         if (log_status != null) {
             gv.getLog_status().setColorFilter(Color.argb(255, 255, 0, 0));
         }
+
+        // And finally, update all data providers
+        dp.refreshAll();
     }
 
     /**

--- a/app/src/main/java/cloudcity/MainActivityExtensions.java
+++ b/app/src/main/java/cloudcity/MainActivityExtensions.java
@@ -1,11 +1,16 @@
 package cloudcity;
 
+import static cloudcity.CloudCityConstants.CLOUD_CITY_CC_LOGGING;
+import static cloudcity.CloudCityConstants.CLOUD_CITY_GENERAL_LOGGING;
 import static cloudcity.CloudCityConstants.CLOUD_CITY_SERVER_URL;
 import static cloudcity.CloudCityConstants.CLOUD_CITY_TOKEN;
 
 import android.content.SharedPreferences;
 import android.util.Log;
 
+import androidx.annotation.Nullable;
+
+import de.fraunhofer.fokus.OpenMobileNetworkToolkit.DataProvider.DataProvider;
 import de.fraunhofer.fokus.OpenMobileNetworkToolkit.Preferences.SPType;
 import de.fraunhofer.fokus.OpenMobileNetworkToolkit.Preferences.SharedPreferencesGrouper;
 
@@ -16,8 +21,18 @@ public class MainActivityExtensions {
      * @param TAG
      * @param spg
      */
-    public static void performMainActivityThing(String TAG, SharedPreferencesGrouper spg) {
+    public static void performMainActivityThing(String TAG, SharedPreferencesGrouper spg, DataProvider dp) {
+        // First, set a listener that will trigger when the actual CC logging changes
+        spg.setListener((sharedPreferences, key) -> {
+            if (key.equalsIgnoreCase(CLOUD_CITY_CC_LOGGING)) {
+                dp.refreshAll();
+            }
+        }, SPType.logging_sp);
+        // Now perform the other stuff, and among other things, change the CC logging
         performMainActivityThing2(TAG, spg.getSharedPreference(SPType.logging_sp));
+
+        // Finally, get rid of the listener we put up there
+        spg.removeListener(SPType.logging_sp);
     }
 
     public static void performMainActivityThing2(String TAG, SharedPreferences sp) {
@@ -34,5 +49,11 @@ public class MainActivityExtensions {
             Log.d(TAG, "onCreate: Cloud city token not set, setting default");
             sp.edit().putString(CLOUD_CITY_TOKEN, CloudCityParamsRepository.getInstance().getServerToken()).commit();
         }
+
+        // Finally, turn on CloudCity logging by default
+        sp.edit()
+                .putBoolean(CLOUD_CITY_GENERAL_LOGGING, true)
+                .putBoolean(CLOUD_CITY_CC_LOGGING, true)
+                .commit();
     }
 }

--- a/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/DetailFragment.java
+++ b/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/DetailFragment.java
@@ -27,6 +27,7 @@ import android.widget.LinearLayout;
 import android.widget.TableLayout;
 import android.widget.TableRow;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.cardview.widget.CardView;
@@ -532,16 +533,19 @@ public class DetailFragment extends Fragment {
         NetworkCallback nc = new NetworkCallback(context);
         TableLayout tl = new TableLayout(context);
 
-        addRows(tl, new String[][]{
-                {getString(R.string.networkOperatorName), ni.getNetworkOperatorName()},
-                {getString(R.string.simOperatorName), ni.getSimOperatorName()},
-                {getString(R.string.networkSpecifier), ni.getNetworkSpecifier()},
-                {getString(R.string.dataState), ni.getDataStateString()},
-                {getString(R.string.dataNetworkType), ni.getDataNetworkTypeString()},
-                {getString(R.string.phoneType), ni.getPhoneTypeString()},
-                {getString(R.string.preferredOpportunisticDataSubscriptionId), String.valueOf(ni.getPreferredOpportunisticDataSubscriptionId())},
-        }, true);
-
+        if (ni != null) {
+            addRows(tl, new String[][]{
+                    {getString(R.string.networkOperatorName), ni.getNetworkOperatorName()},
+                    {getString(R.string.simOperatorName), ni.getSimOperatorName()},
+                    {getString(R.string.networkSpecifier), ni.getNetworkSpecifier()},
+                    {getString(R.string.dataState), ni.getDataStateString()},
+                    {getString(R.string.dataNetworkType), ni.getDataNetworkTypeString()},
+                    {getString(R.string.phoneType), ni.getPhoneTypeString()},
+                    {getString(R.string.preferredOpportunisticDataSubscriptionId), String.valueOf(ni.getPreferredOpportunisticDataSubscriptionId())},
+            }, true);
+        } else {
+            Toast.makeText(getContext(), "NetworkInformation was not ready!", Toast.LENGTH_SHORT).show();
+        }
 
         if (GlobalVars.getInstance().isPermission_phone_state() && tm.getSimState() == TelephonyManager.SIM_STATE_READY) {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {

--- a/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/LoggingService.java
+++ b/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/LoggingService.java
@@ -454,7 +454,7 @@ public class LoggingService extends Service {
 
     private void setupNotificationUpdate() {
         Log.d(TAG, "setupNotificationUpdate");
-        notificationHandlerThread = new HandlerThread("CloudCityHandlerThread");
+        notificationHandlerThread = new HandlerThread("NotificationHandlerThread");
         notificationHandlerThread.start();
         notificationHandler = new Handler(Objects.requireNonNull(notificationHandlerThread.getLooper()));
         notificationHandler.post(notification_updater);

--- a/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/LoggingService.java
+++ b/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/LoggingService.java
@@ -19,6 +19,7 @@ import android.icu.text.SimpleDateFormat;
 import android.os.Build;
 import android.os.Environment;
 import android.os.Handler;
+import android.os.HandlerThread;
 import android.os.IBinder;
 import android.os.Looper;
 import android.util.Log;
@@ -62,9 +63,13 @@ public class LoggingService extends Service {
     DataProvider dp;
     SharedPreferencesGrouper spg;
     private Handler notificationHandler;
+    private HandlerThread notificationHandlerThread;
     private Handler remoteInfluxHandler;
+    private HandlerThread remoteInfluxHandlerThread;
     private Handler localInfluxHandler;
+    private HandlerThread localInfluxHandlerThread;
     private Handler localFileHandler;
+    private HandlerThread localFileHandlerThread;
     private List<Point> logFilePoints;
     private FileOutputStream stream;
     private int interval;
@@ -421,8 +426,7 @@ public class LoggingService extends Service {
             Log.d(TAG,e.toString());
         }
 
-        localFileHandler = new Handler(Objects.requireNonNull(Looper.myLooper()));
-        localFileHandler.post(localFileUpdate);
+        initLocalFileHandlerAndItsThread();
     }
 
     private void stopLocalFile() {
@@ -437,11 +441,22 @@ public class LoggingService extends Service {
                 Log.d(TAG,e.toString());
             }
         }
+
+        if (localFileHandlerThread != null) {
+            localFileHandlerThread.quitSafely();
+            try {
+                localFileHandlerThread.join();
+            } catch (InterruptedException e) {
+                Log.e(TAG, "Exception happened!! "+e, e);
+            }
+        }
     }
 
     private void setupNotificationUpdate() {
         Log.d(TAG, "setupNotificationUpdate");
-        notificationHandler = new Handler(Objects.requireNonNull(Looper.myLooper()));
+        notificationHandlerThread = new HandlerThread("CloudCityHandlerThread");
+        notificationHandlerThread.start();
+        notificationHandler = new Handler(Objects.requireNonNull(notificationHandlerThread.getLooper()));
         notificationHandler.post(notification_updater);
     }
 
@@ -450,13 +465,25 @@ public class LoggingService extends Service {
         notificationHandler.removeCallbacks(notification_updater);
         builder.setContentText(null);
         nm.notify(1, builder.build());
+
+        if (notificationHandlerThread != null) {
+            notificationHandlerThread.quitSafely();
+            try {
+                notificationHandlerThread.join();
+            } catch (InterruptedException e) {
+                Log.e(TAG, "Exception happened!! "+e, e);
+            }
+            notificationHandlerThread = null;
+        }
     }
 
     private void setupLocalInfluxDB() {
         Log.d(TAG, "setupLocalInfluxDB");
         lic = InfluxdbConnections.getLicInstance(getApplicationContext());
         Objects.requireNonNull(lic).open_write_api();
-        localInfluxHandler = new Handler(Objects.requireNonNull(Looper.myLooper()));
+        localInfluxHandlerThread = new HandlerThread("LocalInfluxHandlerThread");
+        localInfluxHandlerThread.start();
+        localInfluxHandler = new Handler(Objects.requireNonNull(localFileHandlerThread.getLooper()));
         localInfluxHandler.post(localInfluxUpdate);
     }
 
@@ -472,6 +499,15 @@ public class LoggingService extends Service {
         if (lic != null) {
             lic.disconnect();
         }
+        if (localInfluxHandlerThread != null) {
+            localInfluxHandlerThread.quitSafely();
+            try {
+                localInfluxHandlerThread.join();
+            } catch (InterruptedException e) {
+                Log.e(TAG, "Exception happened!! "+e, e);
+            }
+            localInfluxHandlerThread = null;
+        }
     }
 
     /**
@@ -481,7 +517,9 @@ public class LoggingService extends Service {
         Log.d(TAG, "setupRemoteInfluxDB");
         ic = InfluxdbConnections.getRicInstance(getApplicationContext());
         Objects.requireNonNull(ic).open_write_api();
-        remoteInfluxHandler = new Handler(Objects.requireNonNull(Looper.myLooper()));
+        remoteInfluxHandlerThread = new HandlerThread("RemoteInfluxHandlerThread");
+        remoteInfluxHandlerThread.start();
+        remoteInfluxHandler = new Handler(Objects.requireNonNull(remoteInfluxHandlerThread.getLooper()));
         remoteInfluxHandler.post(RemoteInfluxUpdate);
         ImageView log_status = gv.getLog_status();
         if (log_status != null) {
@@ -503,6 +541,16 @@ public class LoggingService extends Service {
             }
         }
 
+        if (remoteInfluxHandlerThread != null) {
+            remoteInfluxHandlerThread.quitSafely();
+            try {
+                remoteInfluxHandlerThread.join();
+            } catch (InterruptedException e) {
+                Log.e(TAG, "Exception happened!! "+e, e);
+            }
+            remoteInfluxHandlerThread = null;
+        }
+
         // close disconnect influx connection if existing
         if (ic != null) {
             ic.disconnect();
@@ -518,5 +566,12 @@ public class LoggingService extends Service {
     @Override
     public IBinder onBind(Intent intent) {
         return null;
+    }
+
+    private void initLocalFileHandlerAndItsThread() {
+        localFileHandlerThread = new HandlerThread("LocalFileHandlerThread");
+        localFileHandlerThread.start();
+        localFileHandler = new Handler(Objects.requireNonNull(localFileHandlerThread.getLooper()));
+        localFileHandler.post(localFileUpdate);
     }
 }

--- a/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/MainActivity.java
+++ b/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/MainActivity.java
@@ -109,10 +109,6 @@ public class MainActivity extends AppCompatActivity implements PreferenceFragmen
         pm = getPackageManager();
         feature_telephony = pm.hasSystemFeature(PackageManager.FEATURE_TELEPHONY);
 
-        // CloudCity thing
-        MainActivityExtensions.performMainActivityThing(TAG, spg);
-        // Rest of how it was before
-
         // populate global vars we use in other parts of the app.
         gv.setPm(pm);
         gv.setPermission_phone_state(ActivityCompat.checkSelfPermission(this, Manifest.permission.READ_PHONE_STATE) == PackageManager.PERMISSION_GRANTED);
@@ -177,6 +173,10 @@ public class MainActivity extends AppCompatActivity implements PreferenceFragmen
                 gv.setCcm((CarrierConfigManager) getSystemService(Context.CARRIER_CONFIG_SERVICE));
             }
         } //todo this will go very wrong on android devices without telephony api, maybe show warning and exit?
+
+        // CloudCity thing
+        MainActivityExtensions.performMainActivityThing(TAG, spg, dp);
+        // Rest of how it was before
 
         gv.set_dp(dp);
 

--- a/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/QuickFragment.java
+++ b/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/QuickFragment.java
@@ -1,5 +1,6 @@
 package de.fraunhofer.fokus.OpenMobileNetworkToolkit;
 
+import android.app.Activity;
 import android.content.Context;
 import android.graphics.Color;
 import android.os.Bundle;
@@ -10,6 +11,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.LinearLayout;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import androidx.cardview.widget.CardView;
 import androidx.fragment.app.Fragment;
@@ -305,31 +307,36 @@ public class QuickFragment extends Fragment {
      final Runnable updateUI = new Runnable() {
         @Override
         public void run() {
-            mainLL.removeAllViews();
-            List<CellInformation> cellInformationList = dp.getRegisteredCells();
-            List<CellInformation> neighborCells = dp.getNeighbourCellInformation();
-            if(cellInformationList.isEmpty()){
-                LinearLayout error = new LinearLayout(context);
-                error.setLayoutParams(new LinearLayout.LayoutParams(
-                        ViewGroup.LayoutParams.MATCH_PARENT,
-                        ViewGroup.LayoutParams.MATCH_PARENT
-                ));
-                error.setOrientation(LinearLayout.VERTICAL);
-                TextView errorText = new TextView(context);
-                errorText.setLayoutParams(new LinearLayout.LayoutParams(
-                        ViewGroup.LayoutParams.MATCH_PARENT,
-                        ViewGroup.LayoutParams.MATCH_PARENT
-                ));
-                errorText.setText(getString(R.string.cell_na));
-                error.addView(errorText);
-                mainLL.addView(error);
-            } else {
-                cellInformationList.forEach(cellInformation -> addCellInformationToView(cellInformation));
-            }
-            if (spg.getSharedPreference(SPType.default_sp).getBoolean("show_neighbour_cells", false)) {
-                if(!neighborCells.isEmpty()){
-                    neighborCells.forEach(cellInformation -> addCellInformationToView(cellInformation));
+            Activity parentActivity = getActivity();
+            if (parentActivity != null && isAdded()) {
+                mainLL.removeAllViews();
+                List<CellInformation> cellInformationList = dp.getRegisteredCells();
+                List<CellInformation> neighborCells = dp.getNeighbourCellInformation();
+                if (cellInformationList.isEmpty()) {
+                    LinearLayout error = new LinearLayout(context);
+                    error.setLayoutParams(new LinearLayout.LayoutParams(
+                            ViewGroup.LayoutParams.MATCH_PARENT,
+                            ViewGroup.LayoutParams.MATCH_PARENT
+                    ));
+                    error.setOrientation(LinearLayout.VERTICAL);
+                    TextView errorText = new TextView(context);
+                    errorText.setLayoutParams(new LinearLayout.LayoutParams(
+                            ViewGroup.LayoutParams.MATCH_PARENT,
+                            ViewGroup.LayoutParams.MATCH_PARENT
+                    ));
+                    errorText.setText(getString(R.string.cell_na));
+                    error.addView(errorText);
+                    mainLL.addView(error);
+                } else {
+                    cellInformationList.forEach(cellInformation -> addCellInformationToView(cellInformation));
                 }
+                if (spg.getSharedPreference(SPType.default_sp).getBoolean("show_neighbour_cells", false)) {
+                    if (!neighborCells.isEmpty()) {
+                        neighborCells.forEach(cellInformation -> addCellInformationToView(cellInformation));
+                    }
+                }
+            } else {
+                Toast.makeText(getContext(), "Tried updating QuickFragment UI while not being added/attached!", Toast.LENGTH_SHORT).show();
             }
             updateUIHandler.postDelayed(updateUI, 500);
         }

--- a/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/QuickFragment.java
+++ b/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/QuickFragment.java
@@ -1,6 +1,5 @@
 package de.fraunhofer.fokus.OpenMobileNetworkToolkit;
 
-import android.app.Activity;
 import android.content.Context;
 import android.graphics.Color;
 import android.os.Bundle;
@@ -11,8 +10,8 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.LinearLayout;
 import android.widget.TextView;
-import android.widget.Toast;
 
+import androidx.annotation.StringRes;
 import androidx.cardview.widget.CardView;
 import androidx.fragment.app.Fragment;
 
@@ -307,36 +306,31 @@ public class QuickFragment extends Fragment {
      final Runnable updateUI = new Runnable() {
         @Override
         public void run() {
-            Activity parentActivity = getActivity();
-            if (parentActivity != null && isAdded()) {
-                mainLL.removeAllViews();
-                List<CellInformation> cellInformationList = dp.getRegisteredCells();
-                List<CellInformation> neighborCells = dp.getNeighbourCellInformation();
-                if (cellInformationList.isEmpty()) {
-                    LinearLayout error = new LinearLayout(context);
-                    error.setLayoutParams(new LinearLayout.LayoutParams(
-                            ViewGroup.LayoutParams.MATCH_PARENT,
-                            ViewGroup.LayoutParams.MATCH_PARENT
-                    ));
-                    error.setOrientation(LinearLayout.VERTICAL);
-                    TextView errorText = new TextView(context);
-                    errorText.setLayoutParams(new LinearLayout.LayoutParams(
-                            ViewGroup.LayoutParams.MATCH_PARENT,
-                            ViewGroup.LayoutParams.MATCH_PARENT
-                    ));
-                    errorText.setText(getString(R.string.cell_na));
-                    error.addView(errorText);
-                    mainLL.addView(error);
-                } else {
-                    cellInformationList.forEach(cellInformation -> addCellInformationToView(cellInformation));
-                }
-                if (spg.getSharedPreference(SPType.default_sp).getBoolean("show_neighbour_cells", false)) {
-                    if (!neighborCells.isEmpty()) {
-                        neighborCells.forEach(cellInformation -> addCellInformationToView(cellInformation));
-                    }
-                }
+            mainLL.removeAllViews();
+            List<CellInformation> cellInformationList = dp.getRegisteredCells();
+            List<CellInformation> neighborCells = dp.getNeighbourCellInformation();
+            if(cellInformationList.isEmpty()){
+                LinearLayout error = new LinearLayout(context);
+                error.setLayoutParams(new LinearLayout.LayoutParams(
+                        ViewGroup.LayoutParams.MATCH_PARENT,
+                        ViewGroup.LayoutParams.MATCH_PARENT
+                ));
+                error.setOrientation(LinearLayout.VERTICAL);
+                TextView errorText = new TextView(context);
+                errorText.setLayoutParams(new LinearLayout.LayoutParams(
+                        ViewGroup.LayoutParams.MATCH_PARENT,
+                        ViewGroup.LayoutParams.MATCH_PARENT
+                ));
+                errorText.setText(getSafeString(R.string.cell_na));
+                error.addView(errorText);
+                mainLL.addView(error);
             } else {
-                Toast.makeText(getContext(), "Tried updating QuickFragment UI while not being added/attached!", Toast.LENGTH_SHORT).show();
+                cellInformationList.forEach(cellInformation -> addCellInformationToView(cellInformation));
+            }
+            if (spg.getSharedPreference(SPType.default_sp).getBoolean("show_neighbour_cells", false)) {
+                if(!neighborCells.isEmpty()){
+                    neighborCells.forEach(cellInformation -> addCellInformationToView(cellInformation));
+                }
             }
             updateUIHandler.postDelayed(updateUI, 500);
         }
@@ -349,5 +343,13 @@ public class QuickFragment extends Fragment {
         mainLL = view.findViewById(R.id.quick_fragment);
         updateUIHandler.postDelayed(updateUI, 500);
         return view;
+    }
+
+    public String getSafeString(@StringRes int resId) {
+        if (context == null) {
+            return "NOT AVAILABLE AT THE MOMENT";
+        } else {
+            return context.getResources().getString(resId);
+        }
     }
 }

--- a/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/cloudCity/models/NetworkDataModel.java
+++ b/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/cloudCity/models/NetworkDataModel.java
@@ -70,4 +70,17 @@ public class NetworkDataModel {
     public void setValues(MeasurementsModel values) {
         this.values = values;
     }
+
+    @Override
+    public String toString() {
+        return "NetworkDataModel{" +
+                "category='" + category + '\'' +
+                ", latitude=" + latitude +
+                ", longitude=" + longitude +
+                ", accuracy=" + accuracy +
+                ", speed=" + speed +
+                ", cellData=" + cellData +
+                ", values=" + values +
+                '}';
+    }
 }


### PR DESCRIPTION
This PR mostly plugs the holes/problems in QuickFragment and DetailFragment (aka the 'left' and 'right' fragments of the app) so they don't mess with views while they're not visible/added and don't constantly and consistently crash due to race conditions touching nulls.

Additionally, it moves things posted by Handlers to background HandlerThreads for things that can be moved to background threads (that don't interact with any views)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced logging and error handling for data retrieval processes.
	- Improved user feedback with toast messages when network information is unavailable.
	- Added a method to provide a string representation of network data.
	- Introduced a safer method for string retrieval to prevent null pointer exceptions.
	- Optimized local file logging management with dedicated threading.
	- Improved logging functionality in the PingService for better performance.
	- Added new logging configuration options in Cloud City.

- **Bug Fixes**
	- Prevented potential crashes by checking if fragments are attached before UI updates.

- **Documentation**
	- Updated import statements to support new functionalities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->