### PR TITLE
Get rid of the potential discrepancy between SharedPref and out Repo

### DIFF
--- a/app/src/main/java/cloudcity/MainActivityExtensions.java
+++ b/app/src/main/java/cloudcity/MainActivityExtensions.java
@@ -26,9 +26,10 @@ public class MainActivityExtensions {
     public static void performMainActivityThing(String TAG, SharedPreferencesGrouper spg, DataProvider dp) {
         // First, set a listener that will trigger when the actual CC logging changes
         spg.setListener((sharedPreferences, key) -> {
-            if (key != null && !key.isEmpty() && CloudCityUtil.isBlank(key)) {
+            if (key != null && !key.isEmpty() && !CloudCityUtil.isBlank(key)) {
                 switch (key) {
                     case CLOUD_CITY_CC_LOGGING: {
+                        // This might cause a double refresh with the thing in LoggingServiceExtensions but... oh well.
                         dp.refreshAll();
                     }
                     break;
@@ -45,11 +46,6 @@ public class MainActivityExtensions {
                     }
                     break;
                 }
-            }
-
-            if (key.equalsIgnoreCase(CLOUD_CITY_CC_LOGGING)) {
-                // This might cause a double refresh with the thing in LoggingServiceExtensions but... oh well.
-                dp.refreshAll();
             }
         }, SPType.logging_sp);
         // Now perform the other stuff, and among other things, change the CC logging
@@ -74,9 +70,13 @@ public class MainActivityExtensions {
             Log.d(TAG, "onCreate: Cloud city token not set, setting default");
             sp.edit().putString(CLOUD_CITY_TOKEN, CloudCityParamsRepository.getInstance().getServerToken()).commit();
         }
+    }
 
+    public static void turnOnCloudCityLoggingAfterPermissionsGranted(SharedPreferencesGrouper spg) {
         // Finally, turn on CloudCity logging by default
-        sp.edit()
+        spg
+                .getSharedPreference(SPType.logging_sp)
+                .edit()
                 .putBoolean(CLOUD_CITY_GENERAL_LOGGING, true)
                 .putBoolean(CLOUD_CITY_CC_LOGGING, true)
                 .commit();

--- a/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/MainActivity.java
+++ b/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/MainActivity.java
@@ -329,6 +329,7 @@ public class MainActivity extends AppCompatActivity implements PreferenceFragmen
      */
     @Override
     public void onRequestPermissionsResult(int i, @NonNull String[] strArr, @NonNull int[] iArr) {
+        Log.d(TAG, "--> onRequestPermissionsResult()");
         super.onRequestPermissionsResult(i, strArr, iArr);
 
         for (int j = 0; j < strArr.length; j = j + 1) {
@@ -341,8 +342,18 @@ public class MainActivity extends AppCompatActivity implements PreferenceFragmen
                 } else {
                     Log.d(TAG, "Got ACCESS_BACKGROUND_LOCATION Permission");
                 }
+
+                // Since we have the FINE_LOCATION, we can start sending to the server
+
+                // To avoid the possibility of a race-condition between 'spg' initialization and this callback,
+                // lets maybe also initiallize the SPG for the first time here as well.
+                MainActivityExtensions
+                        .turnOnCloudCityLoggingAfterPermissionsGranted(
+                                SharedPreferencesGrouper.getInstance(getApplicationContext())
+                        );
             }
         }
+        Log.d(TAG, "<-- onRequestPermissionsResult()");
     }
 
     /**


### PR DESCRIPTION
When the app starts, the SharedPref is prefilled from hardcoded parameters from the Repository. The networking requests still use the value from SharedPref unless they're empty; in case they're empty we use the ones from Repo. However, if the user goes into the Settings and changes the server URL/token to something else, we will have a discrepancy between the repository and what's stored in the SharedPref until the app is restarted which is when the repo will sync to what's in the SharedPrefs.

Use the SharedPrefListener approach to listen to these important key changes, and immediatelly update the repo if/when they change.

EDIT: also ended up fixing a big issue with when the CloudCity logging is started, since it requires FINE_LOCATION permission in order to work fine.
Starting it before that permission is granted kinda gets it stuck into a bad state, so that (apart from other bugs) was fixed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced data handling for Cloud City server updates with a new parameter for refreshing data.
	- Improved management of shared preferences for server URL and token updates.
	- Added logging functionality to track permission request results and enhance clarity.

- **Bug Fixes**
	- Refined logic for requesting background location permissions to ensure proper handling.

- **Documentation**
	- Updated JavaDoc comments for better clarity on method parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->