### PR TITLE
Fix NPE encountered after clearing data

### DIFF
--- a/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/QuickFragment.java
+++ b/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/QuickFragment.java
@@ -325,11 +325,19 @@ public class QuickFragment extends Fragment {
                 error.addView(errorText);
                 mainLL.addView(error);
             } else {
-                cellInformationList.forEach(cellInformation -> addCellInformationToView(cellInformation));
+                // We will filter out nulls from the list and only add non-null ones
+                cellInformationList
+                        .stream()
+                        .filter(Objects::nonNull)
+                        .forEach(cellInformation -> addCellInformationToView(cellInformation));
             }
             if (spg.getSharedPreference(SPType.default_sp).getBoolean("show_neighbour_cells", false)) {
                 if(!neighborCells.isEmpty()){
-                    neighborCells.forEach(cellInformation -> addCellInformationToView(cellInformation));
+                    // Similarly to above, we will also filter out nulls from the list and only add non-null ones
+                    neighborCells
+                            .stream()
+                            .filter(Objects::nonNull)
+                            .forEach(cellInformation -> addCellInformationToView(cellInformation));
                 }
             }
             updateUIHandler.postDelayed(updateUI, 500);

--- a/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/QuickFragment.java
+++ b/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/QuickFragment.java
@@ -126,8 +126,6 @@ public class QuickFragment extends Fragment {
      * @param cellInformation The cell information
      */
     private void addCellInformationToView(CellInformation cellInformation){
-        // If we're passed a null element, don't do anything else just return
-        if (cellInformation == null) return;
         LayoutInflater inflater = (LayoutInflater) context.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
         switch (cellInformation.getCellType()) {
             case LTE:

--- a/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/QuickFragment.java
+++ b/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/QuickFragment.java
@@ -126,6 +126,8 @@ public class QuickFragment extends Fragment {
      * @param cellInformation The cell information
      */
     private void addCellInformationToView(CellInformation cellInformation){
+        // If we're passed a null element, don't do anything else just return
+        if (cellInformation == null) return;
         LayoutInflater inflater = (LayoutInflater) context.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
         switch (cellInformation.getCellType()) {
             case LTE:


### PR DESCRIPTION
Didn't manage to repro, but doesn't mean it's not a real issue.

anyways, i expect the `switch(cellInformation)` is really looking into the ordinal to compare with the other enum ordinals, and when we pass a null element - which would make sense since we just cleared data - it will surely throw a null in there. don't know how yet, but... lets keep it stable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved null handling for cell information, preventing potential errors in the user interface.

This enhancement increases the app's stability by ensuring that null values are filtered out, thereby maintaining a smooth and reliable user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->