### PR TITLE
Pull the RSSNR from signal strength data

### DIFF
--- a/app/src/main/java/cloudcity/LoggingServiceExtensions.java
+++ b/app/src/main/java/cloudcity/LoggingServiceExtensions.java
@@ -257,7 +257,7 @@ public class LoggingServiceExtensions {
         return measurements;
     }
 
-    private static void updateMeasurementModelByCell(MeasurementsModel measurements, CellInformation cellForUpdating) {
+    private static void updateMeasurementModelByCell(@NonNull MeasurementsModel measurements, @NonNull CellInformation cellForUpdating) {
         if (cellForUpdating instanceof NRInformation) {
             NRInformation nrCell = (NRInformation) cellForUpdating;
             measurements.setCsirsrp(nrCell.getCsirsrp());

--- a/app/src/main/java/cloudcity/LoggingServiceExtensions.java
+++ b/app/src/main/java/cloudcity/LoggingServiceExtensions.java
@@ -142,20 +142,11 @@ public class LoggingServiceExtensions {
 
     private static NetworkDataModel getCloudCityData() {
         List<CellInformation> cellsInfo = dp.getCellInformation();
+        List<CellInformation> signalInfo = dp.getSignalStrengthInformation();
         LocationInformation location = dp.getLocation();
-        CellInformation currentCell = null;
 
-        for (CellInformation ci: cellsInfo) {
-            if (!ci.isRegistered()) {
-                continue;
-            }
-
-            currentCell = ci;
-        }
-
-        if (currentCell == null) {
-            return null;
-        }
+        CellInformation currentCell = findRegisteredCell(cellsInfo);
+        CellInformation currentSignal = findRegisteredCell(signalInfo);
 
         String category = currentCell.getCellType().toString();
 
@@ -169,9 +160,34 @@ public class LoggingServiceExtensions {
         dataModel.setSpeed(location.getSpeed() * 3.6);
 
         dataModel.setCellData(getCellInfoModel(category, currentCell));
-        dataModel.setValues(getMeasurementsModel(category, currentCell));
+        MeasurementsModel currentCellMeasurements = getMeasurementsModel(category, currentCell);
+        MeasurementsModel signalStrengthMeasurements = getMeasurementsModel(category, currentSignal);
+
+        Log.d(TAG, "currentCellMeasurements: "+currentCellMeasurements);
+        Log.d(TAG, "signalStrengthMeasurements: "+signalStrengthMeasurements);
+
+        dataModel.setValues(currentCellMeasurements);
 
         return dataModel;
+    }
+
+    /**
+     * Finds a regustered cell information in a list of cell informations
+     * @param cellList
+     * @return
+     */
+    public static CellInformation findRegisteredCell(List<CellInformation> cellList) {
+        CellInformation retVal = null;
+
+        for (CellInformation ci: cellList) {
+            if (!ci.isRegistered()) {
+                continue;
+            }
+
+            retVal = ci;
+        }
+
+        return retVal;
     }
 
     private static @NonNull CellInfoModel getCellInfoModel(String category, CellInformation currentCell) {

--- a/app/src/main/java/cloudcity/LoggingServiceExtensions.java
+++ b/app/src/main/java/cloudcity/LoggingServiceExtensions.java
@@ -165,7 +165,6 @@ public class LoggingServiceExtensions {
         dataModel.setSpeed(location.getSpeed() * 3.6);
 
         dataModel.setCellData(getCellInfoModel(category, currentCell));
-
         // Lets initialize our MeasurementModel for sending from the registered cell model, then overwrite it's values
         // with what we found in the SignalInformation
         MeasurementsModel modelForSending = getMeasurementsModel(category, currentCell);
@@ -177,11 +176,11 @@ public class LoggingServiceExtensions {
     }
 
     /**
-     * Finds a regustered cell information in a list of cell informations
+     * Finds a registered cell information in a list of cell informations
      * @param cellList
-     * @return
+     * @return the first registered cell in the list, or null if no registered cells were found
      */
-    public static CellInformation findRegisteredCell(List<CellInformation> cellList) {
+    public static CellInformation findRegisteredCell(@NonNull List<CellInformation> cellList) {
         CellInformation retVal = null;
 
         for (CellInformation ci: cellList) {

--- a/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/cloudCity/models/MeasurementsModel.java
+++ b/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/cloudCity/models/MeasurementsModel.java
@@ -128,4 +128,20 @@ public class MeasurementsModel {
     public void setDummy(Integer dummy) {
         this.dummy = dummy;
     }
+
+    @Override
+    public String toString() {
+        return "MeasurementsModel{" +
+                "rsrp=" + rsrp +
+                ", rsrq=" + rsrq +
+                ", rssnr=" + rssnr +
+                ", csirsrp=" + csirsrp +
+                ", csirsrq=" + csirsrq +
+                ", csisinr=" + csisinr +
+                ", ssrsrp=" + ssrsrp +
+                ", ssrsrq=" + ssrsrq +
+                ", sssinr=" + sssinr +
+                ", dummy=" + dummy +
+                '}';
+    }
 }


### PR DESCRIPTION
Issue link:
https://github.com/orgs/Cloud-City-RS/projects/1/views/7?pane=issue&itemId=86174193&issue=Cloud-City-RS%7COMNTelcoMetrics%7C21

Turns out, we were using Cell data for everything.

And while this still doesn't change what's being sent out... it can be used to check the difference between the two rssnr values we could send.

So we're going to change this to do something else:
1) initialize the data model from the current registered cell
2) update the model from the signal strength information (if signal strength is non-null and non-empty)
3) send that.

Yep, after making necessary changes and logging, I was on-spot with mixing these two measurement values.
```
currentCellMeasurements: MeasurementsModel{rsrp=-94, rsrq=-14, rssnr=null, csirsrp=null, csirsrq=null, csisinr=null, ssrsrp=null, ssrsrq=null, sssinr=null, dummy=null}

signalStrengthMeasurements: MeasurementsModel{rsrp=-98, rsrq=-15, rssnr=-1, csirsrp=null, csirsrq=null, csisinr=null, ssrsrp=null, ssrsrq=null, sssinr=null, dummy=null}

modelForSending: MeasurementsModel{rsrp=-98, rsrq=-15, rssnr=-1, csirsrp=null, csirsrq=null, csisinr=null, ssrsrp=null, ssrsrq=null, sssinr=null, dummy=null}
```
While the current registered cell had only RSRP and RSRQ, the signal strength has those two and RSSNR;
so when we mix both we get to send all 3.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a method to streamline the identification of registered network cells.
	- Added a new `toString()` method for better representation of measurement data.

- **Bug Fixes**
	- Improved error handling and data retrieval processes for network cell information.

- **Refactor**
	- Enhanced modularity and clarity of data handling logic within the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->