### PR TITLE
Fix changing servers

### DIFF
--- a/app/src/main/java/cloudcity/CloudCityParamsRepository.java
+++ b/app/src/main/java/cloudcity/CloudCityParamsRepository.java
@@ -16,8 +16,8 @@ public class CloudCityParamsRepository {
 
     private SharedPreferences sharedPrefs;
 
-    private String serverUrl;
-    private String serverToken;
+    private volatile String serverUrl;
+    private volatile String serverToken;
 
 
     private CloudCityParamsRepository(Context context) {
@@ -83,7 +83,7 @@ public class CloudCityParamsRepository {
      * Return cached {@link #serverUrl} if non-empty, or fetches it from the shared prefs
      * @return the cached serverURL or the one from shared prefs; if both of these are empty/nonexistant then an empty string is returned
      */
-    public String getServerUrl() {
+    public synchronized String getServerUrl() {
         String retVal;
         if (isParamPresent(serverUrl)) {
             retVal = serverUrl;
@@ -98,7 +98,7 @@ public class CloudCityParamsRepository {
      * Return cached {@link #serverToken} if non-empty, or fetches it from the shared prefs
      * @return the cached serverToken or the one from shared prefs; if both of these are empty/nonexistant then an empty string is returned
      */
-    public String getServerToken() {
+    public synchronized String getServerToken() {
         String retVal;
         if (isParamPresent(serverToken)) {
             retVal = serverToken;
@@ -114,7 +114,7 @@ public class CloudCityParamsRepository {
      * @param newUrl the new server URL to put in
      * @see #putStringKey(String, String)
      */
-    public void setServerUrl(String newUrl) {
+    public synchronized void setServerUrl(String newUrl) {
         putStringKey(CLOUD_CITY_SERVER_URL, newUrl);
         serverUrl = newUrl;
     }
@@ -124,7 +124,7 @@ public class CloudCityParamsRepository {
      * @param newToken the new server token to put in
      * @see #putStringKey(String, String)
      */
-    public void setServerToken(String newToken) {
+    public synchronized void setServerToken(String newToken) {
         putStringKey(CLOUD_CITY_TOKEN, newToken);
         serverToken = newToken;
     }

--- a/app/src/main/java/cloudcity/LoggingServiceExtensions.java
+++ b/app/src/main/java/cloudcity/LoggingServiceExtensions.java
@@ -103,8 +103,7 @@ public class LoggingServiceExtensions {
         handlerThread = new HandlerThread("CloudCityHandlerThread");
         handlerThread.start();
         CloudCityHandler = new Handler(Objects.requireNonNull(handlerThread.getLooper()));
-        if (!isUpdating.get()) {
-            isUpdating.compareAndSet(false, true);
+        if (isUpdating.compareAndSet(false, true)) {
             CloudCityHandler.post(CloudCityUpdate);
         }
         ImageView log_status = gv.getLog_status();
@@ -125,7 +124,10 @@ public class LoggingServiceExtensions {
         if (CloudCityHandler != null) {
             try {
                 CloudCityHandler.removeCallbacks(CloudCityUpdate);
-                isUpdating.compareAndSet(true, false);
+                boolean unset = isUpdating.compareAndSet(true, false);
+                if(!unset) {
+                    Log.e(TAG, "There was a problem with updating 'isUpdating', expected 'true' but was 'false' instead");
+                }
             } catch (java.lang.NullPointerException e) {
                 Log.d(TAG, "trying to stop cloud city service while it was not running");
             }

--- a/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/Preferences/SharedPreferencesGrouper.java
+++ b/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/Preferences/SharedPreferencesGrouper.java
@@ -7,7 +7,9 @@ import android.util.Log;
 
 import androidx.preference.PreferenceManager;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 
 public class SharedPreferencesGrouper {
     private static final String TAG = "SharedPreferencesGrouper";
@@ -20,7 +22,7 @@ public class SharedPreferencesGrouper {
     private final SharedPreferences defaultSP;
     private final SharedPreferences pingSP;
     private final Context ct;
-    private HashMap <SPType, SharedPreferences.OnSharedPreferenceChangeListener> spMap = new HashMap<>();
+    private HashMap <SPType, List<SharedPreferences.OnSharedPreferenceChangeListener>> spMap = new HashMap<>();
     public String getSharedPreferenceIdentifier(SPType key)  {
         return this.ct.getPackageName()+"_"+key.toString();
     }
@@ -74,20 +76,87 @@ public class SharedPreferencesGrouper {
         return sp;
     }
 
-    public void removeListener(SPType key){
+    /**
+     * Removes a particular {@code listener} for a particular {@code key}
+     * @param key the key holding the listener
+     * @param listener the listener to remove
+     */
+    public void removeListener(SPType key, SharedPreferences.OnSharedPreferenceChangeListener listener) {
         SharedPreferences sp = this.getSharedPreference(key);
         if(sp == null) {
             Log.e(TAG, "SharedPreferences not found for "+key);
             return;
         }
-        SharedPreferences.OnSharedPreferenceChangeListener listener = this.spMap.get(key);
-        if(listener == null) {
+        List<SharedPreferences.OnSharedPreferenceChangeListener> listenerList = this.spMap.get(key);
+        if(listenerList == null || !listenerList.contains(listener)) {
             Log.e(TAG, "Listener not found for "+key);
             return;
         }
         sp.unregisterOnSharedPreferenceChangeListener(listener);
-        this.spMap.remove(key);
+        listenerList.remove(listener);
+        // If listener list isn't empty, write in the new reduced list, otherwise just delete the whole key
+        if (!listenerList.isEmpty()) {
+            this.spMap.put(key, listenerList);
+        } else {
+            this.spMap.remove(key);
+        }
         Log.i(TAG, "Listener removed for "+key);
+    }
+
+    /**
+     * Removes all listeners for a particular {@link SPType} {@code key}
+     * @param key the key for which to remove all listeners
+     */
+    public void removeAllListeners(SPType key){
+        SharedPreferences sp = this.getSharedPreference(key);
+        if(sp == null) {
+            Log.e(TAG, "SharedPreferences not found for "+key);
+            return;
+        }
+        List<SharedPreferences.OnSharedPreferenceChangeListener> listenerList = this.spMap.get(key);
+        if(listenerList == null) {
+            Log.e(TAG, "Listener(s) not found for "+key);
+            return;
+        }
+        // Unregister all listeners
+        for (SharedPreferences.OnSharedPreferenceChangeListener listener : listenerList) {
+            sp.unregisterOnSharedPreferenceChangeListener(listener);
+        }
+        // Delete them all from the map
+        this.spMap.remove(key);
+        Log.i(TAG, "Listener(s) removed for "+key);
+    }
+
+    /**
+     * Searches for the passed-in {@code listener} and removes it if found. The listener
+     * <b>must have been</b> already added via {@link #setListener(SharedPreferences.OnSharedPreferenceChangeListener, SPType)}
+     * @param listener the listener to add
+     */
+    public void removeListener(SharedPreferences.OnSharedPreferenceChangeListener listener){
+        for (SPType potentialMatch : spMap.keySet()) {
+            SharedPreferences sp = this.getSharedPreference(potentialMatch);
+            if (sp == null) {
+                Log.e(TAG, "SharedPreferences not found for " + potentialMatch);
+                continue;
+            }
+            List<SharedPreferences.OnSharedPreferenceChangeListener> listenerList = this.spMap.get(potentialMatch);
+            if (listener == null || !listenerList.contains(listener)) {
+                Log.e(TAG, "Listener not found for " + potentialMatch);
+                continue;
+            }
+            // Now the easy part, when we know which SharedPref owns the listener and it's in the
+            // registered listenerList, just remove it from the list and cleanup the key if the list
+            // remains empty
+            listenerList.remove(listener);
+            sp.unregisterOnSharedPreferenceChangeListener(listener);
+            // If the listenerList is empty, remove the whole key from the map, otherwise update value
+            if (listenerList.isEmpty()) {
+                this.spMap.remove(potentialMatch);
+            } else {
+                this.spMap.put(potentialMatch, listenerList);
+            }
+            Log.i(TAG, "Listener removed for " + potentialMatch);
+        }
     }
     public HashMap<SPType,SharedPreferences> getAllSharedPreferences() {
 
@@ -103,8 +172,14 @@ public class SharedPreferencesGrouper {
             Log.e(TAG, "SharedPreferences not found for "+key);
             return;
         }
+        List listenerList = this.spMap.get(key);
+        if (listenerList == null) {
+            listenerList = new ArrayList();
+        }
+
         sp.registerOnSharedPreferenceChangeListener(listener);
-        this.spMap.put(key, listener);
+        listenerList.add(listener);
+        this.spMap.put(key, listenerList);
         Log.i(TAG, "Listener registered for "+key);
     }
 

--- a/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/Preferences/SharedPreferencesGrouper.java
+++ b/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/Preferences/SharedPreferencesGrouper.java
@@ -5,11 +5,13 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.util.Log;
 
+import androidx.annotation.NonNull;
 import androidx.preference.PreferenceManager;
 
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class SharedPreferencesGrouper {
     private static final String TAG = "SharedPreferencesGrouper";
@@ -22,7 +24,7 @@ public class SharedPreferencesGrouper {
     private final SharedPreferences defaultSP;
     private final SharedPreferences pingSP;
     private final Context ct;
-    private HashMap <SPType, List<SharedPreferences.OnSharedPreferenceChangeListener>> spMap = new HashMap<>();
+    private ConcurrentHashMap <SPType, Set<SharedPreferences.OnSharedPreferenceChangeListener>> spMap = new ConcurrentHashMap<>();
     public String getSharedPreferenceIdentifier(SPType key)  {
         return this.ct.getPackageName()+"_"+key.toString();
     }
@@ -81,13 +83,13 @@ public class SharedPreferencesGrouper {
      * @param key the key holding the listener
      * @param listener the listener to remove
      */
-    public void removeListener(SPType key, SharedPreferences.OnSharedPreferenceChangeListener listener) {
+    public void removeListener(@NonNull SPType key, @NonNull SharedPreferences.OnSharedPreferenceChangeListener listener) {
         SharedPreferences sp = this.getSharedPreference(key);
         if(sp == null) {
             Log.e(TAG, "SharedPreferences not found for "+key);
             return;
         }
-        List<SharedPreferences.OnSharedPreferenceChangeListener> listenerList = this.spMap.get(key);
+        Set<SharedPreferences.OnSharedPreferenceChangeListener> listenerList = this.spMap.get(key);
         if(listenerList == null || !listenerList.contains(listener)) {
             Log.e(TAG, "Listener not found for "+key);
             return;
@@ -113,7 +115,7 @@ public class SharedPreferencesGrouper {
             Log.e(TAG, "SharedPreferences not found for "+key);
             return;
         }
-        List<SharedPreferences.OnSharedPreferenceChangeListener> listenerList = this.spMap.get(key);
+        Set<SharedPreferences.OnSharedPreferenceChangeListener> listenerList = this.spMap.get(key);
         if(listenerList == null) {
             Log.e(TAG, "Listener(s) not found for "+key);
             return;
@@ -132,14 +134,14 @@ public class SharedPreferencesGrouper {
      * <b>must have been</b> already added via {@link #setListener(SharedPreferences.OnSharedPreferenceChangeListener, SPType)}
      * @param listener the listener to add
      */
-    public void removeListener(SharedPreferences.OnSharedPreferenceChangeListener listener){
+    public void removeListener(@NonNull SharedPreferences.OnSharedPreferenceChangeListener listener){
         for (SPType potentialMatch : spMap.keySet()) {
             SharedPreferences sp = this.getSharedPreference(potentialMatch);
             if (sp == null) {
                 Log.e(TAG, "SharedPreferences not found for " + potentialMatch);
                 continue;
             }
-            List<SharedPreferences.OnSharedPreferenceChangeListener> listenerList = this.spMap.get(potentialMatch);
+            Set<SharedPreferences.OnSharedPreferenceChangeListener> listenerList = this.spMap.get(potentialMatch);
             if (listener == null || !listenerList.contains(listener)) {
                 Log.e(TAG, "Listener not found for " + potentialMatch);
                 continue;
@@ -166,15 +168,15 @@ public class SharedPreferencesGrouper {
         }
         return spList;
     }
-    public void setListener(SharedPreferences.OnSharedPreferenceChangeListener listener, SPType key) {
+    public void setListener(@NonNull SharedPreferences.OnSharedPreferenceChangeListener listener, @NonNull SPType key) {
         SharedPreferences sp = this.getSharedPreference(key);
         if(sp == null) {
             Log.e(TAG, "SharedPreferences not found for "+key);
             return;
         }
-        List listenerList = this.spMap.get(key);
+        Set listenerList = this.spMap.get(key);
         if (listenerList == null) {
-            listenerList = new ArrayList();
+            listenerList = new HashSet<SharedPreferences.OnSharedPreferenceChangeListener>();
         }
 
         sp.registerOnSharedPreferenceChangeListener(listener);

--- a/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/Preferences/SharedPreferencesGrouper.java
+++ b/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/Preferences/SharedPreferencesGrouper.java
@@ -83,7 +83,7 @@ public class SharedPreferencesGrouper {
      * @param key the key holding the listener
      * @param listener the listener to remove
      */
-    public void removeListener(@NonNull SPType key, @NonNull SharedPreferences.OnSharedPreferenceChangeListener listener) {
+    public synchronized void removeListener(@NonNull SPType key, @NonNull SharedPreferences.OnSharedPreferenceChangeListener listener) {
         SharedPreferences sp = this.getSharedPreference(key);
         if(sp == null) {
             Log.e(TAG, "SharedPreferences not found for "+key);
@@ -109,7 +109,7 @@ public class SharedPreferencesGrouper {
      * Removes all listeners for a particular {@link SPType} {@code key}
      * @param key the key for which to remove all listeners
      */
-    public void removeAllListeners(SPType key){
+    public synchronized void removeAllListeners(SPType key){
         SharedPreferences sp = this.getSharedPreference(key);
         if(sp == null) {
             Log.e(TAG, "SharedPreferences not found for "+key);
@@ -134,7 +134,7 @@ public class SharedPreferencesGrouper {
      * <b>must have been</b> already added via {@link #setListener(SharedPreferences.OnSharedPreferenceChangeListener, SPType)}
      * @param listener the listener to add
      */
-    public void removeListener(@NonNull SharedPreferences.OnSharedPreferenceChangeListener listener){
+    public synchronized void removeListener(@NonNull SharedPreferences.OnSharedPreferenceChangeListener listener){
         for (SPType potentialMatch : spMap.keySet()) {
             SharedPreferences sp = this.getSharedPreference(potentialMatch);
             if (sp == null) {
@@ -168,13 +168,13 @@ public class SharedPreferencesGrouper {
         }
         return spList;
     }
-    public void setListener(@NonNull SharedPreferences.OnSharedPreferenceChangeListener listener, @NonNull SPType key) {
+    public synchronized void setListener(@NonNull SharedPreferences.OnSharedPreferenceChangeListener listener, @NonNull SPType key) {
         SharedPreferences sp = this.getSharedPreference(key);
         if(sp == null) {
             Log.e(TAG, "SharedPreferences not found for "+key);
             return;
         }
-        Set listenerList = this.spMap.get(key);
+        Set<SharedPreferences.OnSharedPreferenceChangeListener> listenerList = this.spMap.get(key);
         if (listenerList == null) {
             listenerList = new HashSet<SharedPreferences.OnSharedPreferenceChangeListener>();
         }

--- a/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/SettingPreferences/LoggingSettingsFragment.java
+++ b/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/SettingPreferences/LoggingSettingsFragment.java
@@ -14,6 +14,7 @@ import android.text.InputType;
 import android.util.Log;
 
 import androidx.preference.PreferenceFragmentCompat;
+import androidx.preference.PreferenceScreen;
 import androidx.preference.SwitchPreferenceCompat;
 
 import de.fraunhofer.fokus.OpenMobileNetworkToolkit.R;
@@ -48,6 +49,18 @@ public class LoggingSettingsFragment extends PreferenceFragmentCompat
         if (s.equals("enable_logging")) {
             boolean logger = sharedPreferences.getBoolean("enable_logging", false);
             Log.d(TAG, "Logger update: " + logger);
+        }
+    }
+
+    @Override
+    public void onDestroyView() {
+        super.onDestroyView();
+        PreferenceScreen prefScreen = getPreferenceScreen();
+        if (prefScreen != null) {
+            SharedPreferences prefsSharedPref = prefScreen.getSharedPreferences();
+            if (prefsSharedPref != null) {
+                prefsSharedPref.unregisterOnSharedPreferenceChangeListener(this);
+            }
         }
     }
 }

--- a/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/cloudCity/NetworkClient.java
+++ b/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/cloudCity/NetworkClient.java
@@ -1,31 +1,45 @@
 package de.fraunhofer.fokus.OpenMobileNetworkToolkit.cloudCity;
 
+import android.util.Log;
+
 import java.util.Locale;
 
 import retrofit2.Retrofit;
 import retrofit2.converter.gson.GsonConverterFactory;
 
 public class NetworkClient {
+    private static final String TAG = "NetworkClient";
 
     private static Retrofit retrofit;
+    private static String currentClientBaseUrl;
 
     /**
-     * Get retrofit client to be used for the communication. Creates singleton.
+     * Get retrofit client to be used for the communication. Creates and memoizes the client which will
+     * be reused as long as the URL stays the same - when the URL changes and differs from what the
+     * memoized ("singleton") client was initialized with - a new client gets initialized with the new base URL.
+     *
      * @return Instance of retrofit client to be used.
      */
     public static Retrofit getRetrofitClient(String url) {
-        if (retrofit == null) {
+        String baseUrl = String.format(Locale.US, "https://%s/", url);
+        // If we don't have a retrofit client, or the URL we're targetting is different
+        // than what the previous client was initialized with - build a new client;
+        // otherwise return the last initialized one
+        if (retrofit == null || !baseUrl.equalsIgnoreCase(currentClientBaseUrl)) {
             if (url == null || url.isEmpty()){
                 return null;
             }
 
-            String baseUrl = String.format(Locale.US, "https://%s/", url);
+            if (!url.equalsIgnoreCase(currentClientBaseUrl)) {
+                Log.w(TAG, "URL has changed from previous Retrofit client's base URL, instantiating new client...");
+            }
 
             retrofit = new Retrofit.Builder()
                     .baseUrl(baseUrl)
                     .client(CustomClient.getUnsafeOkHttpClient())
                     .addConverterFactory(GsonConverterFactory.create())
                     .build();
+            currentClientBaseUrl = baseUrl;
         }
 
         return retrofit;

--- a/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/cloudCity/NetworkClient.java
+++ b/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/cloudCity/NetworkClient.java
@@ -3,6 +3,7 @@ package de.fraunhofer.fokus.OpenMobileNetworkToolkit.cloudCity;
 import android.util.Log;
 
 import java.util.Locale;
+import java.util.concurrent.locks.ReentrantLock;
 
 import retrofit2.Retrofit;
 import retrofit2.converter.gson.GsonConverterFactory;
@@ -10,8 +11,10 @@ import retrofit2.converter.gson.GsonConverterFactory;
 public class NetworkClient {
     private static final String TAG = "NetworkClient";
 
-    private static Retrofit retrofit;
-    private static String currentClientBaseUrl;
+    private static volatile Retrofit retrofit;
+    private static volatile String currentClientBaseUrl;
+    private static ReentrantLock lock = new ReentrantLock();
+    private static final Object lockObject = new Object();
 
     /**
      * Get retrofit client to be used for the communication. Creates and memoizes the client which will
@@ -20,27 +23,32 @@ public class NetworkClient {
      *
      * @return Instance of retrofit client to be used.
      */
-    public static Retrofit getRetrofitClient(String url) {
+    public static synchronized Retrofit getRetrofitClient(String url) {
         String baseUrl = String.format(Locale.US, "https://%s/", url);
         // If we don't have a retrofit client, or the URL we're targetting is different
         // than what the previous client was initialized with - build a new client;
         // otherwise return the last initialized one
-        if (retrofit == null || !baseUrl.equalsIgnoreCase(currentClientBaseUrl)) {
-            if (url == null || url.isEmpty()){
-                return null;
-            }
+        if (lock.tryLock()) {
+            synchronized (lockObject) {
+                if (retrofit == null || !baseUrl.equalsIgnoreCase(currentClientBaseUrl)) {
+                    if (url == null || url.isEmpty()) {
+                        return null;
+                    }
 
-            if (!url.equalsIgnoreCase(currentClientBaseUrl)) {
-                Log.w(TAG, "URL has changed from previous Retrofit client's base URL, instantiating new client...");
-            }
+                    if (!url.equalsIgnoreCase(currentClientBaseUrl)) {
+                        Log.w(TAG, "URL has changed from previous Retrofit client's base URL, instantiating new client...");
+                    }
 
-            retrofit = new Retrofit.Builder()
-                    .baseUrl(baseUrl)
-                    .client(CustomClient.getUnsafeOkHttpClient())
-                    .addConverterFactory(GsonConverterFactory.create())
-                    .build();
-            currentClientBaseUrl = baseUrl;
+                    retrofit = new Retrofit.Builder()
+                            .baseUrl(baseUrl)
+                            .client(CustomClient.getUnsafeOkHttpClient())
+                            .addConverterFactory(GsonConverterFactory.create())
+                            .build();
+                    currentClientBaseUrl = baseUrl;
+                }
+            }
         }
+        lock.unlock();
 
         return retrofit;
     }


### PR DESCRIPTION
Turns out, the Cloud City URL setting in the settings screen was useless because while we were changing it, and updating the repository, it was never really reused since the Retrofit would just get initialized once with the initial (prefilled) value of the server URL and that's that.

So apart from doing some other beneficial changes, this PR makes it possible to recreate the Retrofit client when necessary (when URL changes) and 'enable' us to change servers on the fly while the app is running.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Enhanced thread safety for server URL and token management.
	- Improved listener management in shared preferences, allowing multiple listeners per preference type.
	- Streamlined update logic to prevent concurrent updates.
	- Improved control flow and error handling for Retrofit client initialization based on URL changes.
	- Added cleanup method to prevent memory leaks by unregistering listeners when the fragment's view is destroyed.

- **Bug Fixes**
	- Resolved issues with concurrent access to server URL and token methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->