### PR TITLE
Iperf3 runner and the whole thing

### DIFF
--- a/app/src/main/java/cloudcity/CloudCityOMNTApplication.java
+++ b/app/src/main/java/cloudcity/CloudCityOMNTApplication.java
@@ -14,10 +14,10 @@ public class CloudCityOMNTApplication extends Application {
         super.onCreate();
         CloudCityParamsRepository.initialize(getApplicationContext());
 
-        Iperf3Monitor.initialize();
+        Iperf3Monitor.initialize(getApplicationContext());
         iperf3Monitor = Iperf3Monitor.getInstance();
 
-        iperf3Monitor.startListeningForIperf3Updates(getApplicationContext(), new Iperf3Monitor.Iperf3MonitorCompletionListener() {
+        iperf3Monitor.startListeningForIperf3Updates(new Iperf3Monitor.Iperf3MonitorCompletionListener() {
             @Override
             public void onIperf3TestCompleted(MetricsPOJO metrics) {
                 android.util.Log.wtf(TAG, "One iperf3 cycle is completed! received metrics: "+metrics);

--- a/app/src/main/java/cloudcity/CloudCityParamsRepository.java
+++ b/app/src/main/java/cloudcity/CloudCityParamsRepository.java
@@ -16,8 +16,8 @@ public class CloudCityParamsRepository {
 
     private SharedPreferences sharedPrefs;
 
-    private String serverUrl;
-    private String serverToken;
+    private volatile String serverUrl;
+    private volatile String serverToken;
 
 
     private CloudCityParamsRepository(Context context) {
@@ -83,7 +83,7 @@ public class CloudCityParamsRepository {
      * Return cached {@link #serverUrl} if non-empty, or fetches it from the shared prefs
      * @return the cached serverURL or the one from shared prefs; if both of these are empty/nonexistant then an empty string is returned
      */
-    public String getServerUrl() {
+    public synchronized String getServerUrl() {
         String retVal;
         if (isParamPresent(serverUrl)) {
             retVal = serverUrl;
@@ -98,7 +98,7 @@ public class CloudCityParamsRepository {
      * Return cached {@link #serverToken} if non-empty, or fetches it from the shared prefs
      * @return the cached serverToken or the one from shared prefs; if both of these are empty/nonexistant then an empty string is returned
      */
-    public String getServerToken() {
+    public synchronized String getServerToken() {
         String retVal;
         if (isParamPresent(serverToken)) {
             retVal = serverToken;
@@ -114,7 +114,7 @@ public class CloudCityParamsRepository {
      * @param newUrl the new server URL to put in
      * @see #putStringKey(String, String)
      */
-    public void setServerUrl(String newUrl) {
+    public synchronized void setServerUrl(String newUrl) {
         putStringKey(CLOUD_CITY_SERVER_URL, newUrl);
         serverUrl = newUrl;
     }
@@ -124,7 +124,7 @@ public class CloudCityParamsRepository {
      * @param newToken the new server token to put in
      * @see #putStringKey(String, String)
      */
-    public void setServerToken(String newToken) {
+    public synchronized void setServerToken(String newToken) {
         putStringKey(CLOUD_CITY_TOKEN, newToken);
         serverToken = newToken;
     }

--- a/app/src/main/java/cloudcity/GPSMonitor.java
+++ b/app/src/main/java/cloudcity/GPSMonitor.java
@@ -44,7 +44,7 @@ public class GPSMonitor {
     private ValueMonitor valueMonitor;
 
     private volatile float lastSpeed;
-    private volatile AtomicLong timeUnderThreshold;
+    private volatile AtomicLong timeUnderThreshold = new AtomicLong(0);
 
     public GPSMonitor(Context context) {
         this.context = context;

--- a/app/src/main/java/cloudcity/GPSMonitor.java
+++ b/app/src/main/java/cloudcity/GPSMonitor.java
@@ -12,15 +12,38 @@ import android.util.Log;
 import androidx.core.app.ActivityCompat;
 
 import java.util.List;
+import java.util.TimerTask;
+
+import javax.annotation.Nullable;
+
+import cloudcity.dataholders.TimerWrapper;
 
 public class GPSMonitor {
     private static final String TAG = GPSMonitor.class.getSimpleName();
     private static final long GPS_POLLING_SPEED_IN_MS = 1000L;//10L; //was 1000L
     private static final long GPS_POLLING_MIN_DIST_IN_M = 0L; //1L; //was 0
 
+    /**
+     * The thresshold value we need to be under to start the Iperf3 test
+     */
+    private static final int THRESHOLD_VALUE = 5;
+    /**
+     * How long do we need to be under threshold to fire a callback
+     */
+    private static final int THRESHOLD_DURATION = 5000;
+    /**
+     * How often to poll the value, in milliseconds
+     */
+    private static final int VALUE_MONITOR_INTERVAL = 500;//1000;
+
+
     private LocationManager locationManager;
     private LocationListener locationListener;
     private Context context;
+    private ValueMonitor valueMonitor;
+
+    private volatile float lastSpeed;
+    private volatile float timeUnderThreshold;
 
     public GPSMonitor(Context context) {
         this.context = context;
@@ -35,6 +58,7 @@ public class GPSMonitor {
                     if (location.hasSpeedAccuracy()) {
                         Log.d(TAG, "Location has speed accuracy! speed: "+location.getSpeedAccuracyMetersPerSecond());
                     }
+                    lastSpeed = location.getSpeed();
                 }
             }
 
@@ -62,10 +86,101 @@ public class GPSMonitor {
         List<String> allGpsProviders = locationManager.getAllProviders();
         Log.d(TAG, "all GPS providers: "+allGpsProviders);
         locationManager.requestLocationUpdates(LocationManager.GPS_PROVIDER, GPS_POLLING_SPEED_IN_MS, GPS_POLLING_MIN_DIST_IN_M, locationListener);
+
+        Log.d(TAG, "Starting speed polling task...");
+
+        valueMonitor = new ValueMonitor();
+        valueMonitor.setCallback(() -> {
+            Iperf3Monitor.getInstance().startDefault15secTest(context);
+        });
+        valueMonitor.startMonitoring();
+        /*
+        timer = new Timer();
+        timer.scheduleAtFixedRate(new TimerTask() {
+            private long startTime = System.currentTimeMillis();
+
+            @Override
+            public void run() {
+                if (variable >= X) {
+                    isUnderX = false;
+                    timer.cancel();
+                } else if (System.currentTimeMillis() - startTime >= DURATION) {
+                    System.out.println("Variable has been under " + X + " for 5 seconds straight.");
+                    timer.cancel();
+                }
+            }
+        }, 0, CHECK_INTERVAL);
+         */
+
+
         Log.d(TAG, "<-- startMonitoring()");
     }
 
     public void stopMonitoring() {
         locationManager.removeUpdates(locationListener);
+    }
+
+    private class ValueMonitor {
+        private static final String TAG = "ValueMonitor";
+
+        private final TimerWrapper timer;
+        /**
+         * Callback that will be invoked when the monitored value has been under {@link #THRESHOLD_VALUE}
+         * for at least {@link #THRESHOLD_DURATION} millis
+         */
+        private @Nullable ValueMonitorCallback callback;
+
+        public ValueMonitor() {
+            // Start the timer as a daemon thread
+            timer = new TimerWrapper(true);
+        }
+
+        /**
+         * Set or clear the {@link #callback} parameter
+         * @param callback the new callback to set
+         */
+        public void setCallback(@Nullable ValueMonitorCallback callback) {
+            this.callback = callback;
+        }
+
+        public void startMonitoring() {
+            timer.schedule(new TimerTask() {
+                @Override
+                public void run() {
+                    monitorValue();
+                }
+            }, 0, VALUE_MONITOR_INTERVAL);
+        }
+
+        public void stopMonitoring() {
+            timer.stop();
+        }
+
+        /**
+         * Logic to monitor the value and track the time under threshold
+         */
+        private void monitorValue() {
+            if (lastSpeed < THRESHOLD_VALUE) {
+                // If value is under threshold, increment the time under threshold
+                timeUnderThreshold += VALUE_MONITOR_INTERVAL;
+
+                // Check if the time under threshold exceeds 5 seconds
+                if (timeUnderThreshold >= THRESHOLD_DURATION) {
+                    Log.d(TAG, "value has been under threshold for "+timeUnderThreshold+"ms, firing callback");
+                    // Trigger the callback if the condition is met
+                    callback.onUnderThresholdValueForAtLeastThresholdDuration();
+
+                    // Reset the time tracking after triggering callback
+                    timeUnderThreshold = 0;
+                }
+            } else {
+                // If the value is above the threshold, reset the time tracking
+                timeUnderThreshold = 0;
+            }
+        }
+    }
+
+    interface ValueMonitorCallback {
+        void onUnderThresholdValueForAtLeastThresholdDuration();
     }
 }

--- a/app/src/main/java/cloudcity/GPSMonitor.java
+++ b/app/src/main/java/cloudcity/GPSMonitor.java
@@ -144,6 +144,10 @@ public class GPSMonitor {
             this.callback = callback;
         }
 
+        /**
+         * Start a new {@link TimerTask} on the {@link #timer} which will call {@link #monitorValue()}
+         * every {@link #VALUE_MONITOR_INTERVAL}
+         */
         public void startMonitoring() {
             timer.schedule(new TimerTask() {
                 @Override
@@ -153,6 +157,9 @@ public class GPSMonitor {
             }, 0, VALUE_MONITOR_INTERVAL);
         }
 
+        /**
+         * Stops monitoring and calls {@link #timer}'s {@link TimerWrapper#stop()}
+         */
         public void stopMonitoring() {
             timer.stop();
         }

--- a/app/src/main/java/cloudcity/GPSMonitor.java
+++ b/app/src/main/java/cloudcity/GPSMonitor.java
@@ -94,24 +94,6 @@ public class GPSMonitor {
             Iperf3Monitor.getInstance().startDefault15secTest(context);
         });
         valueMonitor.startMonitoring();
-        /*
-        timer = new Timer();
-        timer.scheduleAtFixedRate(new TimerTask() {
-            private long startTime = System.currentTimeMillis();
-
-            @Override
-            public void run() {
-                if (variable >= X) {
-                    isUnderX = false;
-                    timer.cancel();
-                } else if (System.currentTimeMillis() - startTime >= DURATION) {
-                    System.out.println("Variable has been under " + X + " for 5 seconds straight.");
-                    timer.cancel();
-                }
-            }
-        }, 0, CHECK_INTERVAL);
-         */
-
 
         Log.d(TAG, "<-- startMonitoring()");
     }

--- a/app/src/main/java/cloudcity/GPSMonitor.java
+++ b/app/src/main/java/cloudcity/GPSMonitor.java
@@ -19,13 +19,18 @@ import javax.annotation.Nullable;
 
 import cloudcity.dataholders.TimerWrapper;
 
+/**
+ * Class for monitoring GPS location and speed via {@link LocationManager}, monitoring if the speed
+ * is under threshold {@link #THRESHOLD_VALUE} for minimum threshold millis {@link #THRESHOLD_DURATION},
+ * firing callbacks via {@link ValueMonitorCallback} when that condition has been met.
+ */
 public class GPSMonitor {
     private static final String TAG = GPSMonitor.class.getSimpleName();
-    private static final long GPS_POLLING_SPEED_IN_MS = 1000L;//10L; //was 1000L
-    private static final long GPS_POLLING_MIN_DIST_IN_M = 0L; //1L; //was 0
+    private static final long GPS_POLLING_SPEED_IN_MS = 1000L;
+    private static final long GPS_POLLING_MIN_DIST_IN_M = 0L;
 
     /**
-     * The thresshold value we need to be under to start the Iperf3 test
+     * The threshold value we need to be under to start the Iperf3 test
      */
     private static final int THRESHOLD_VALUE = 5;
     /**
@@ -33,9 +38,10 @@ public class GPSMonitor {
      */
     private static final int THRESHOLD_DURATION = 5000;
     /**
-     * How often to poll the value, in milliseconds
+     * How often to poll the value, in milliseconds<p>
+     * Try to keep it faster then {@link #GPS_POLLING_SPEED_IN_MS}
      */
-    private static final int VALUE_MONITOR_INTERVAL = 500;//1000;
+    private static final int VALUE_MONITOR_INTERVAL = 500;
 
 
     private LocationManager locationManager;
@@ -76,6 +82,10 @@ public class GPSMonitor {
         Log.d(TAG, "GPSMonitor initialized!");
     }
 
+    /**
+     * Start monitoring for GPS location changes, and turn on the internal {@link ValueMonitor}
+     * and assign it a {@link ValueMonitorCallback} to call {@link Iperf3Monitor#startDefault15secTest()}
+     */
     public void startMonitoring() {
         Log.d(TAG, "--> startMonitoring()");
         if (ActivityCompat.checkSelfPermission(context, Manifest.permission.ACCESS_FINE_LOCATION) != PackageManager.PERMISSION_GRANTED &&
@@ -99,6 +109,11 @@ public class GPSMonitor {
         Log.d(TAG, "<-- startMonitoring()");
     }
 
+    /**
+     * Stop monitoring GPS and speed updates,
+     * remove {@link #locationListener} from the {@link LocationManager} and call
+     * {@link ValueMonitor#stopMonitoring()}
+     */
     public void stopMonitoring() {
         locationManager.removeUpdates(locationListener);
         if(valueMonitor != null) {
@@ -168,7 +183,14 @@ public class GPSMonitor {
         }
     }
 
+    /**
+     * Callback interface for the value monitoring
+     */
     interface ValueMonitorCallback {
+        /**
+         * Callback to be invoked when the speed has been under {@link #THRESHOLD_VALUE}
+         * for at least {@link #THRESHOLD_DURATION} millis
+         */
         void onUnderThresholdValueForAtLeastThresholdDuration();
     }
 }

--- a/app/src/main/java/cloudcity/GPSMonitor.java
+++ b/app/src/main/java/cloudcity/GPSMonitor.java
@@ -91,7 +91,7 @@ public class GPSMonitor {
 
         valueMonitor = new ValueMonitor();
         valueMonitor.setCallback(() -> {
-            Iperf3Monitor.getInstance().startDefault15secTest(context);
+            Iperf3Monitor.getInstance().startDefault15secTest();
         });
         valueMonitor.startMonitoring();
 

--- a/app/src/main/java/cloudcity/Iperf3Monitor.java
+++ b/app/src/main/java/cloudcity/Iperf3Monitor.java
@@ -352,8 +352,10 @@ public class Iperf3Monitor {
                 } else {
                     // This could be either a 1, or a -100; first being a failure, the second one being a 'in progress' value.
                     Log.d(TAG, "latestIperf3RunResult.result was: " + latestIperf3RunResult.result + "\t\tignoring...");
-                    // We want to reset the test running marker on a result of -1 as well
-                    if (latestIperf3RunResult.result == -1) {
+                    // We want to reset the test running marker on any non -100 result as well,
+                    // since -100 means it's still running, and apparently anything non-zero means completion
+                    // 1 for failure, -1 for cancellation and who knows what else
+                    if (latestIperf3RunResult.result != -100) {
                         iperf3TestRunning.compareAndSet(true, false);
                     }
                 }
@@ -680,7 +682,7 @@ public class Iperf3Monitor {
                         iperf3_result = -1;
                     }
                     iperf3RunResultDao.updateResult(iperf3WorkerID, iperf3_result);
-                    Log.d(TAG, "onChanged: iperf3_result: " + iperf3_result);   //TODO emit here
+                    Log.d(TAG, "onChanged: iperf3_result: " + iperf3_result);
                 });
                 iperf3WM.getWorkInfoByIdLiveData(iperf3UP.getId()).observeForever(workInfo -> {
                     boolean iperf3_upload;

--- a/app/src/main/java/cloudcity/Iperf3Monitor.java
+++ b/app/src/main/java/cloudcity/Iperf3Monitor.java
@@ -499,7 +499,6 @@ public class Iperf3Monitor {
 
         String uuid = UUID.randomUUID().toString();
 
-//        input.measurementName = "Iperf3";
         String logFileName = String.format("iperf3_%s_%s.json", iperf3TS, uuid);
 
         String logFileDir =
@@ -507,10 +506,7 @@ public class Iperf3Monitor {
                         .getExternalStoragePublicDirectory(Environment.DIRECTORY_DOCUMENTS)
                         .getAbsolutePath() + "/omnt/iperf3RawLogs/";
 
-//        input.iperf3LogFileName = this.logFileName;
-//        this.rawIperf3file = this.logFileDir + this.logFileName;
         String rawIperf3file = logFileDir + logFileName;
-//        input.iperf3rawIperf3file = this.rawIperf3file;
 
         cmdList.add("--logfile");
         cmdList.add(rawIperf3file);
@@ -663,7 +659,11 @@ public class Iperf3Monitor {
 
             // Check if we have a main thread executor
             if (mainThreadExecutor == null) {
-                mainThreadExecutor = new MainThreadExecutor();
+                synchronized (this) {
+                    if (mainThreadExecutor == null) {
+                        mainThreadExecutor = new MainThreadExecutor();
+                    }
+                }
             }
 
             mainThreadExecutor.execute(() -> {

--- a/app/src/main/java/cloudcity/Iperf3Monitor.java
+++ b/app/src/main/java/cloudcity/Iperf3Monitor.java
@@ -674,13 +674,11 @@ public class Iperf3Monitor {
                 }
 
                 iperf3WM.getWorkInfoByIdLiveData(iperf3WR.getId()).observeForever(workInfo -> {
-                    Log.wtf(TAG, ">> SHARK >>\t\tworkInfo: "+workInfo);
                     int iperf3_result;
                     iperf3_result = workInfo.getOutputData().getInt("iperf3_result", -100);
                     if (workInfo.getState().equals(WorkInfo.State.CANCELLED)) {
                         iperf3_result = -1;
                     }
-                    Log.wtf(TAG, ">> SHARK >>\t\tiperf3_result: "+iperf3_result);
                     iperf3RunResultDao.updateResult(iperf3WorkerID, iperf3_result);
                     Log.d(TAG, "onChanged: iperf3_result: " + iperf3_result);   //TODO emit here
                 });

--- a/app/src/main/java/cloudcity/LoggingServiceExtensions.java
+++ b/app/src/main/java/cloudcity/LoggingServiceExtensions.java
@@ -91,7 +91,7 @@ public class LoggingServiceExtensions {
     /**
      * initialize a new remote Cloud City connection
      */
-    public static void setupCloudCity2(GlobalVars globalVars, int updateInterval, DataProvider dataProvider, SharedPreferences sharedPrefs) {
+    public static void setupCloudCity2(GlobalVars globalVars, int updateInterval, @NonNull DataProvider dataProvider, SharedPreferences sharedPrefs) {
         Log.d(TAG, "setupCloudCity");
 
         gv = globalVars;
@@ -112,7 +112,13 @@ public class LoggingServiceExtensions {
         }
 
         // And finally, update all data providers
-        dp.refreshAll();
+        if (dp != null) {
+            // This has to be done since i'm getting crashes due to this 'dp' being null after the app
+            // works for a while.
+            dp.refreshAll();
+        } else {
+            Log.e(TAG, "DataProvider was null! Didn't refreshAll() internal data caches.");
+        }
     }
 
     /**

--- a/app/src/main/java/cloudcity/LoggingServiceExtensions.java
+++ b/app/src/main/java/cloudcity/LoggingServiceExtensions.java
@@ -77,7 +77,6 @@ public class LoggingServiceExtensions {
                 }
             } catch (Exception e) {
                 Log.e(TAG, "Exception happened! exception "+e, e);
-                throw new RuntimeException(e);
             }
 
             CloudCityHandler.postDelayed(this, interval);
@@ -152,6 +151,10 @@ public class LoggingServiceExtensions {
     }
 
     private static NetworkDataModel getCloudCityData() {
+        if (dp == null) {
+            Log.e(TAG, "DataProvider was null! Bailing out, returning null...");
+            return null;
+        }
         List<CellInformation> cellsInfo = dp.getCellInformation();
         LocationInformation location = dp.getLocation();
         CellInformation currentCell = null;

--- a/app/src/main/java/cloudcity/LoggingServiceExtensions.java
+++ b/app/src/main/java/cloudcity/LoggingServiceExtensions.java
@@ -13,6 +13,7 @@ import androidx.annotation.NonNull;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import de.fraunhofer.fokus.OpenMobileNetworkToolkit.DataProvider.CellInformations.CellInformation;
 import de.fraunhofer.fokus.OpenMobileNetworkToolkit.DataProvider.CellInformations.GSMInformation;
@@ -43,21 +44,17 @@ public class LoggingServiceExtensions {
 
     private static HandlerThread handlerThread;
 
+    private static AtomicBoolean isUpdating = new AtomicBoolean(false);
+
     // Handle remote Cloud City update
     private final static Runnable CloudCityUpdate = new Runnable() {
         @Override
         public void run() {
             try {
                 Log.d(TAG, "run: CC Update");
-
-                String address = sp.getString(CloudCityConstants.CLOUD_CITY_SERVER_URL, "");
-                if (address.isEmpty() || CloudCityUtil.isBlank(address)) {
-                    address = CloudCityParamsRepository.getInstance().getServerUrl();
-                }
-                String token = sp.getString(CloudCityConstants.CLOUD_CITY_TOKEN, "");
-                if (token.isEmpty() || CloudCityUtil.isBlank(token)) {
-                    token = CloudCityParamsRepository.getInstance().getServerToken();
-                }
+                interval = Integer.parseInt(sp.getString("logging_interval", "1000"));
+                String address = CloudCityParamsRepository.getInstance().getServerUrl();
+                String token = CloudCityParamsRepository.getInstance().getServerToken();
 
                 NetworkDataModel data = getCloudCityData();
                 Log.d(TAG, "getCloudCityData() returned "+data);
@@ -66,6 +63,8 @@ public class LoggingServiceExtensions {
                 } else {
                     NetworkDataModelRequest requestData = new NetworkDataModelRequest();
                     requestData.add(data);
+
+                    Log.d(TAG, "sending data at addr=" + address + ", token=" + token + ", interval=" + interval);
 
                     boolean status = CloudCityHelpers.sendData(address, token, requestData);
 
@@ -86,7 +85,7 @@ public class LoggingServiceExtensions {
     };
 
     public static void setupCloudCity(GlobalVars globalVars, int updateInterval, DataProvider dataProvider, SharedPreferencesGrouper spg) {
-        setupCloudCity2(globalVars, updateInterval, dataProvider, spg.getSharedPreference(SPType.default_sp));
+        setupCloudCity2(globalVars, updateInterval, dataProvider, spg.getSharedPreference(SPType.logging_sp));
     }
 
     /**
@@ -104,7 +103,9 @@ public class LoggingServiceExtensions {
         handlerThread = new HandlerThread("CloudCityHandlerThread");
         handlerThread.start();
         CloudCityHandler = new Handler(Objects.requireNonNull(handlerThread.getLooper()));
-        CloudCityHandler.post(CloudCityUpdate);
+        if (isUpdating.compareAndSet(false, true)) {
+            CloudCityHandler.post(CloudCityUpdate);
+        }
         ImageView log_status = gv.getLog_status();
         if (log_status != null) {
             gv.getLog_status().setColorFilter(Color.argb(255, 255, 0, 0));
@@ -123,6 +124,10 @@ public class LoggingServiceExtensions {
         if (CloudCityHandler != null) {
             try {
                 CloudCityHandler.removeCallbacks(CloudCityUpdate);
+                boolean unset = isUpdating.compareAndSet(true, false);
+                if(!unset) {
+                    Log.e(TAG, "There was a problem with updating 'isUpdating', expected 'true' but was 'false' instead");
+                }
             } catch (java.lang.NullPointerException e) {
                 Log.d(TAG, "trying to stop cloud city service while it was not running");
             }

--- a/app/src/main/java/cloudcity/MainThreadExecutor.java
+++ b/app/src/main/java/cloudcity/MainThreadExecutor.java
@@ -2,6 +2,9 @@ package cloudcity;
 
 import android.os.Handler;
 import android.os.Looper;
+
+import androidx.annotation.NonNull;
+
 import java.util.concurrent.Executor;
 
 /**
@@ -11,7 +14,7 @@ public class MainThreadExecutor implements Executor {
     private final Handler handler = new Handler(Looper.getMainLooper());
 
     @Override
-    public void execute(Runnable command) {
+    public void execute(@NonNull Runnable command) {
         handler.post(command);
     }
 }

--- a/app/src/main/java/cloudcity/MainThreadExecutor.java
+++ b/app/src/main/java/cloudcity/MainThreadExecutor.java
@@ -1,0 +1,17 @@
+package cloudcity;
+
+import android.os.Handler;
+import android.os.Looper;
+import java.util.concurrent.Executor;
+
+/**
+ * A poor-man's {@link Executor} that's actually a {@link Handler} backed by {@link Looper#getMainLooper()}
+ */
+public class MainThreadExecutor implements Executor {
+    private final Handler handler = new Handler(Looper.getMainLooper());
+
+    @Override
+    public void execute(Runnable command) {
+        handler.post(command);
+    }
+}

--- a/app/src/main/java/cloudcity/dataholders/Iperf3RunnerData.java
+++ b/app/src/main/java/cloudcity/dataholders/Iperf3RunnerData.java
@@ -7,9 +7,12 @@ import androidx.annotation.NonNull;
 import java.sql.Timestamp;
 import java.util.HashMap;
 
+import cloudcity.Iperf3Monitor;
+import de.fraunhofer.fokus.OpenMobileNetworkToolkit.Iperf3.Iperf3Fragment;
+
 /**
  * A simple POJO/mule class to transfer data between <br>
- * {@link cloudcity.Iperf3Monitor#startDefault15secTest(Context)}<br>
+ * {@link Iperf3Monitor#startDefault15secTest()}<br>
  * and <br>
  * {@link cloudcity.Iperf3Monitor#startIperf3Test(Context, Iperf3RunnerData)}<br>
  * methods
@@ -26,19 +29,23 @@ public class Iperf3RunnerData {
     private final HashMap<String, Boolean> booleanMap;
     @NonNull
     private final Timestamp timestamp;
+    @NonNull
+    private final Iperf3Fragment.Iperf3Input stupidInput;
 
     public Iperf3RunnerData(
             @NonNull String command,
             @NonNull String[] cmdList,
             @NonNull HashMap<String, String> map,
             @NonNull HashMap<String, Boolean> boolMap,
-            @NonNull Timestamp timestamp
+            @NonNull Timestamp timestamp,
+            @NonNull Iperf3Fragment.Iperf3Input originalInput
     ) {
         this.joinedCommand = command;
         this.commandList = cmdList;
         this.dataMap = map;
         this.booleanMap = boolMap;
         this.timestamp = timestamp;
+        this.stupidInput = originalInput;
     }
 
     public @NonNull HashMap<String, String> getStringDataMap() {
@@ -59,5 +66,15 @@ public class Iperf3RunnerData {
 
     public @NonNull Timestamp getTimestamp() {
         return timestamp;
+    }
+
+    /**
+     * You know how that guy from south park says "City Wok"?<br>
+     * Yea, this is that exact same City Input
+     *
+     * @return the {@link Iperf3Fragment.Iperf3Input} city input
+     */
+    public @NonNull Iperf3Fragment.Iperf3Input getCityInput() {
+        return stupidInput;
     }
 }

--- a/app/src/main/java/cloudcity/dataholders/Iperf3RunnerData.java
+++ b/app/src/main/java/cloudcity/dataholders/Iperf3RunnerData.java
@@ -1,0 +1,63 @@
+package cloudcity.dataholders;
+
+import android.content.Context;
+
+import androidx.annotation.NonNull;
+
+import java.sql.Timestamp;
+import java.util.HashMap;
+
+/**
+ * A simple POJO/mule class to transfer data between <br>
+ * {@link cloudcity.Iperf3Monitor#startDefault15secTest(Context)}<br>
+ * and <br>
+ * {@link cloudcity.Iperf3Monitor#startIperf3Test(Context, Iperf3RunnerData)}<br>
+ * methods
+ */
+public class Iperf3RunnerData {
+
+    @NonNull
+    private final String joinedCommand;
+    @NonNull
+    private final String[] commandList;
+    @NonNull
+    private final HashMap<String, String> dataMap;
+    @NonNull
+    private final HashMap<String, Boolean> booleanMap;
+    @NonNull
+    private final Timestamp timestamp;
+
+    public Iperf3RunnerData(
+            @NonNull String command,
+            @NonNull String[] cmdList,
+            @NonNull HashMap<String, String> map,
+            @NonNull HashMap<String, Boolean> boolMap,
+            @NonNull Timestamp timestamp
+    ) {
+        this.joinedCommand = command;
+        this.commandList = cmdList;
+        this.dataMap = map;
+        this.booleanMap = boolMap;
+        this.timestamp = timestamp;
+    }
+
+    public @NonNull HashMap<String, String> getStringDataMap() {
+        return dataMap;
+    }
+
+    public @NonNull HashMap<String, Boolean> getBooleanDataMap() {
+        return booleanMap;
+    }
+
+    public @NonNull String getJoinedCommand() {
+        return joinedCommand;
+    }
+
+    public @NonNull String[] getCommandList() {
+        return commandList;
+    }
+
+    public @NonNull Timestamp getTimestamp() {
+        return timestamp;
+    }
+}

--- a/app/src/main/java/cloudcity/dataholders/Iperf3RunnerData.java
+++ b/app/src/main/java/cloudcity/dataholders/Iperf3RunnerData.java
@@ -6,6 +6,7 @@ import androidx.annotation.NonNull;
 
 import java.sql.Timestamp;
 import java.util.HashMap;
+import java.util.Map;
 
 import cloudcity.Iperf3Monitor;
 import de.fraunhofer.fokus.OpenMobileNetworkToolkit.Iperf3.Iperf3Fragment;
@@ -24,9 +25,9 @@ public class Iperf3RunnerData {
     @NonNull
     private final String[] commandList;
     @NonNull
-    private final HashMap<String, String> dataMap;
+    private final Map<String, String> dataMap;
     @NonNull
-    private final HashMap<String, Boolean> booleanMap;
+    private final Map<String, Boolean> booleanMap;
     @NonNull
     private final Timestamp timestamp;
     @NonNull
@@ -35,8 +36,8 @@ public class Iperf3RunnerData {
     public Iperf3RunnerData(
             @NonNull String command,
             @NonNull String[] cmdList,
-            @NonNull HashMap<String, String> map,
-            @NonNull HashMap<String, Boolean> boolMap,
+            @NonNull Map<String, String> map,
+            @NonNull Map<String, Boolean> boolMap,
             @NonNull Timestamp timestamp,
             @NonNull Iperf3Fragment.Iperf3Input originalInput
     ) {
@@ -48,11 +49,11 @@ public class Iperf3RunnerData {
         this.stupidInput = originalInput;
     }
 
-    public @NonNull HashMap<String, String> getStringDataMap() {
+    public @NonNull Map<String, String> getStringDataMap() {
         return dataMap;
     }
 
-    public @NonNull HashMap<String, Boolean> getBooleanDataMap() {
+    public @NonNull Map<String, Boolean> getBooleanDataMap() {
         return booleanMap;
     }
 

--- a/app/src/main/java/cloudcity/dataholders/TimerWrapper.java
+++ b/app/src/main/java/cloudcity/dataholders/TimerWrapper.java
@@ -1,0 +1,142 @@
+package cloudcity.dataholders;
+
+import java.util.Date;
+import java.util.Timer;
+import java.util.TimerTask;
+
+/**
+ * Because the {@link java.util.Timer} cannot be reused once we call {@link Timer#cancel()} on it,
+ * we need to have this wrapper class to offer the same things the plain Timer did, with a bit less
+ * rigidity
+ */
+public class TimerWrapper {
+
+    private Timer timer;
+    private final boolean isDaemon;
+
+    /**
+     * Creates a new timer whose associated thread may be specified to run as a daemon.
+     * A daemon thread is called for if the timer will be used to schedule repeating
+     * "maintenance activities", which must be performed as long as the application is running,
+     * but should not prolong the lifetime of the application.
+     *
+     * @param isDaemon true if the associated thread should run as a daemon.
+     */
+    public TimerWrapper(boolean isDaemon) {
+        timer = new Timer(isDaemon);
+        this.isDaemon = isDaemon;
+    }
+
+    /**
+     * Schedules the specified task for execution at the specified time.  If
+     * the time is in the past, the task is scheduled for immediate execution.
+     *
+     * @param task task to be scheduled.
+     * @param time time at which task is to be executed.
+     * @throws IllegalArgumentException if {@code time.getTime()} is negative.
+     * @throws IllegalStateException if task was already scheduled or
+     *         cancelled, timer was cancelled, or timer thread terminated.
+     * @throws NullPointerException if {@code task} or {@code time} is null
+     */
+    public void schedule(TimerTask task, Date time) {
+        timer.schedule(task, time);
+    }
+
+    /**
+     * Schedules the specified task for repeated <i>fixed-delay execution</i>,
+     * beginning at the specified time. Subsequent executions take place at
+     * approximately regular intervals, separated by the specified period.
+     *
+     * <p>In fixed-delay execution, each execution is scheduled relative to
+     * the actual execution time of the previous execution.  If an execution
+     * is delayed for any reason (such as garbage collection or other
+     * background activity), subsequent executions will be delayed as well.
+     * In the long run, the frequency of execution will generally be slightly
+     * lower than the reciprocal of the specified period (assuming the system
+     * clock underlying {@code Object.wait(long)} is accurate).  As a
+     * consequence of the above, if the scheduled first time is in the past,
+     * it is scheduled for immediate execution.
+     *
+     * <p>Fixed-delay execution is appropriate for recurring activities
+     * that require "smoothness."  In other words, it is appropriate for
+     * activities where it is more important to keep the frequency accurate
+     * in the short run than in the long run.  This includes most animation
+     * tasks, such as blinking a cursor at regular intervals.  It also includes
+     * tasks wherein regular activity is performed in response to human
+     * input, such as automatically repeating a character as long as a key
+     * is held down.
+     *
+     * @param task   task to be scheduled.
+     * @param firstTime First time at which task is to be executed.
+     * @param period time in milliseconds between successive task executions.
+     * @throws IllegalArgumentException if {@code firstTime.getTime() < 0}, or
+     *         {@code period <= 0}
+     * @throws IllegalStateException if task was already scheduled or
+     *         cancelled, timer was cancelled, or timer thread terminated.
+     * @throws NullPointerException if {@code task} or {@code firstTime} is null
+     */
+    public void schedule(TimerTask task, Date firstTime, long period) {
+        timer.schedule(task, firstTime, period);
+    }
+
+    /**
+     * Schedules the specified task for execution after the specified delay.
+     *
+     * @param task  task to be scheduled.
+     * @param delay delay in milliseconds before task is to be executed.
+     * @throws IllegalArgumentException if {@code delay} is negative, or
+     *         {@code delay + System.currentTimeMillis()} is negative.
+     * @throws IllegalStateException if task was already scheduled or
+     *         cancelled, timer was cancelled, or timer thread terminated.
+     * @throws NullPointerException if {@code task} is null
+     */
+    public void schedule(TimerTask task, long delay) {
+        timer.schedule(task, delay);
+    }
+
+    /**
+     * Schedules the specified task for repeated <i>fixed-delay execution</i>,
+     * beginning after the specified delay.  Subsequent executions take place
+     * at approximately regular intervals separated by the specified period.
+     *
+     * <p>In fixed-delay execution, each execution is scheduled relative to
+     * the actual execution time of the previous execution.  If an execution
+     * is delayed for any reason (such as garbage collection or other
+     * background activity), subsequent executions will be delayed as well.
+     * In the long run, the frequency of execution will generally be slightly
+     * lower than the reciprocal of the specified period (assuming the system
+     * clock underlying {@code Object.wait(long)} is accurate).
+     *
+     * <p>Fixed-delay execution is appropriate for recurring activities
+     * that require "smoothness."  In other words, it is appropriate for
+     * activities where it is more important to keep the frequency accurate
+     * in the short run than in the long run.  This includes most animation
+     * tasks, such as blinking a cursor at regular intervals.  It also includes
+     * tasks wherein regular activity is performed in response to human
+     * input, such as automatically repeating a character as long as a key
+     * is held down.
+     *
+     * @param task   task to be scheduled.
+     * @param delay  delay in milliseconds before task is to be executed.
+     * @param period time in milliseconds between successive task executions.
+     * @throws IllegalArgumentException if {@code delay < 0}, or
+     *         {@code delay + System.currentTimeMillis() < 0}, or
+     *         {@code period <= 0}
+     * @throws IllegalStateException if task was already scheduled or
+     *         cancelled, timer was cancelled, or timer thread terminated.
+     * @throws NullPointerException if {@code task} is null
+     */
+    public void schedule(TimerTask task, long delay, long period) {
+        timer.schedule(task, delay, period);
+    }
+
+    /**
+     * Method that calls {@link Timer#cancel()} on the internal timer, and recreates it immediatelly
+     * after so that we can keep on scheduling new tasks to this object
+     */
+    public void stop() {
+        timer.cancel();
+        // Since cancelling tasks makes the timer unusable anymore, lets just recreate it
+        timer = new Timer(isDaemon);
+    }
+}

--- a/app/src/main/java/cloudcity/dataholders/TimerWrapper.java
+++ b/app/src/main/java/cloudcity/dataholders/TimerWrapper.java
@@ -38,7 +38,7 @@ public class TimerWrapper {
      *         cancelled, timer was cancelled, or timer thread terminated.
      * @throws NullPointerException if {@code task} or {@code time} is null
      */
-    public void schedule(TimerTask task, Date time) {
+    public synchronized void schedule(TimerTask task, Date time) {
         timer.schedule(task, time);
     }
 
@@ -75,7 +75,7 @@ public class TimerWrapper {
      *         cancelled, timer was cancelled, or timer thread terminated.
      * @throws NullPointerException if {@code task} or {@code firstTime} is null
      */
-    public void schedule(TimerTask task, Date firstTime, long period) {
+    public synchronized void schedule(TimerTask task, Date firstTime, long period) {
         timer.schedule(task, firstTime, period);
     }
 
@@ -90,7 +90,7 @@ public class TimerWrapper {
      *         cancelled, timer was cancelled, or timer thread terminated.
      * @throws NullPointerException if {@code task} is null
      */
-    public void schedule(TimerTask task, long delay) {
+    public synchronized void schedule(TimerTask task, long delay) {
         timer.schedule(task, delay);
     }
 
@@ -126,7 +126,7 @@ public class TimerWrapper {
      *         cancelled, timer was cancelled, or timer thread terminated.
      * @throws NullPointerException if {@code task} is null
      */
-    public void schedule(TimerTask task, long delay, long period) {
+    public synchronized void schedule(TimerTask task, long delay, long period) {
         timer.schedule(task, delay, period);
     }
 
@@ -134,7 +134,7 @@ public class TimerWrapper {
      * Method that calls {@link Timer#cancel()} on the internal timer, and recreates it immediatelly
      * after so that we can keep on scheduling new tasks to this object
      */
-    public void stop() {
+    public synchronized void stop() {
         timer.cancel();
         // Since cancelling tasks makes the timer unusable anymore, lets just recreate it
         timer = new Timer(isDaemon);

--- a/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/Preferences/SharedPreferencesGrouper.java
+++ b/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/Preferences/SharedPreferencesGrouper.java
@@ -5,9 +5,13 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.util.Log;
 
+import androidx.annotation.NonNull;
 import androidx.preference.PreferenceManager;
 
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class SharedPreferencesGrouper {
     private static final String TAG = "SharedPreferencesGrouper";
@@ -20,7 +24,7 @@ public class SharedPreferencesGrouper {
     private final SharedPreferences defaultSP;
     private final SharedPreferences pingSP;
     private final Context ct;
-    private HashMap <SPType, SharedPreferences.OnSharedPreferenceChangeListener> spMap = new HashMap<>();
+    private ConcurrentHashMap <SPType, Set<SharedPreferences.OnSharedPreferenceChangeListener>> spMap = new ConcurrentHashMap<>();
     public String getSharedPreferenceIdentifier(SPType key)  {
         return this.ct.getPackageName()+"_"+key.toString();
     }
@@ -74,20 +78,87 @@ public class SharedPreferencesGrouper {
         return sp;
     }
 
-    public void removeListener(SPType key){
+    /**
+     * Removes a particular {@code listener} for a particular {@code key}
+     * @param key the key holding the listener
+     * @param listener the listener to remove
+     */
+    public synchronized void removeListener(@NonNull SPType key, @NonNull SharedPreferences.OnSharedPreferenceChangeListener listener) {
         SharedPreferences sp = this.getSharedPreference(key);
         if(sp == null) {
             Log.e(TAG, "SharedPreferences not found for "+key);
             return;
         }
-        SharedPreferences.OnSharedPreferenceChangeListener listener = this.spMap.get(key);
-        if(listener == null) {
+        Set<SharedPreferences.OnSharedPreferenceChangeListener> listenerList = this.spMap.get(key);
+        if(listenerList == null || !listenerList.contains(listener)) {
             Log.e(TAG, "Listener not found for "+key);
             return;
         }
         sp.unregisterOnSharedPreferenceChangeListener(listener);
-        this.spMap.remove(key);
+        listenerList.remove(listener);
+        // If listener list isn't empty, write in the new reduced list, otherwise just delete the whole key
+        if (!listenerList.isEmpty()) {
+            this.spMap.put(key, listenerList);
+        } else {
+            this.spMap.remove(key);
+        }
         Log.i(TAG, "Listener removed for "+key);
+    }
+
+    /**
+     * Removes all listeners for a particular {@link SPType} {@code key}
+     * @param key the key for which to remove all listeners
+     */
+    public synchronized void removeAllListeners(SPType key){
+        SharedPreferences sp = this.getSharedPreference(key);
+        if(sp == null) {
+            Log.e(TAG, "SharedPreferences not found for "+key);
+            return;
+        }
+        Set<SharedPreferences.OnSharedPreferenceChangeListener> listenerList = this.spMap.get(key);
+        if(listenerList == null) {
+            Log.e(TAG, "Listener(s) not found for "+key);
+            return;
+        }
+        // Unregister all listeners
+        for (SharedPreferences.OnSharedPreferenceChangeListener listener : listenerList) {
+            sp.unregisterOnSharedPreferenceChangeListener(listener);
+        }
+        // Delete them all from the map
+        this.spMap.remove(key);
+        Log.i(TAG, "Listener(s) removed for "+key);
+    }
+
+    /**
+     * Searches for the passed-in {@code listener} and removes it if found. The listener
+     * <b>must have been</b> already added via {@link #setListener(SharedPreferences.OnSharedPreferenceChangeListener, SPType)}
+     * @param listener the listener to add
+     */
+    public synchronized void removeListener(@NonNull SharedPreferences.OnSharedPreferenceChangeListener listener){
+        for (SPType potentialMatch : spMap.keySet()) {
+            SharedPreferences sp = this.getSharedPreference(potentialMatch);
+            if (sp == null) {
+                Log.e(TAG, "SharedPreferences not found for " + potentialMatch);
+                continue;
+            }
+            Set<SharedPreferences.OnSharedPreferenceChangeListener> listenerList = this.spMap.get(potentialMatch);
+            if (listener == null || !listenerList.contains(listener)) {
+                Log.e(TAG, "Listener not found for " + potentialMatch);
+                continue;
+            }
+            // Now the easy part, when we know which SharedPref owns the listener and it's in the
+            // registered listenerList, just remove it from the list and cleanup the key if the list
+            // remains empty
+            listenerList.remove(listener);
+            sp.unregisterOnSharedPreferenceChangeListener(listener);
+            // If the listenerList is empty, remove the whole key from the map, otherwise update value
+            if (listenerList.isEmpty()) {
+                this.spMap.remove(potentialMatch);
+            } else {
+                this.spMap.put(potentialMatch, listenerList);
+            }
+            Log.i(TAG, "Listener removed for " + potentialMatch);
+        }
     }
     public HashMap<SPType,SharedPreferences> getAllSharedPreferences() {
 
@@ -97,14 +168,20 @@ public class SharedPreferencesGrouper {
         }
         return spList;
     }
-    public void setListener(SharedPreferences.OnSharedPreferenceChangeListener listener, SPType key) {
+    public synchronized void setListener(@NonNull SharedPreferences.OnSharedPreferenceChangeListener listener, @NonNull SPType key) {
         SharedPreferences sp = this.getSharedPreference(key);
         if(sp == null) {
             Log.e(TAG, "SharedPreferences not found for "+key);
             return;
         }
+        Set<SharedPreferences.OnSharedPreferenceChangeListener> listenerList = this.spMap.get(key);
+        if (listenerList == null) {
+            listenerList = new HashSet<SharedPreferences.OnSharedPreferenceChangeListener>();
+        }
+
         sp.registerOnSharedPreferenceChangeListener(listener);
-        this.spMap.put(key, listener);
+        listenerList.add(listener);
+        this.spMap.put(key, listenerList);
         Log.i(TAG, "Listener registered for "+key);
     }
 

--- a/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/QuickFragment.java
+++ b/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/QuickFragment.java
@@ -325,11 +325,19 @@ public class QuickFragment extends Fragment {
                 error.addView(errorText);
                 mainLL.addView(error);
             } else {
-                cellInformationList.forEach(cellInformation -> addCellInformationToView(cellInformation));
+                // We will filter out nulls from the list and only add non-null ones
+                cellInformationList
+                        .stream()
+                        .filter(Objects::nonNull)
+                        .forEach(cellInformation -> addCellInformationToView(cellInformation));
             }
             if (spg.getSharedPreference(SPType.default_sp).getBoolean("show_neighbour_cells", false)) {
                 if(!neighborCells.isEmpty()){
-                    neighborCells.forEach(cellInformation -> addCellInformationToView(cellInformation));
+                    // Similarly to above, we will also filter out nulls from the list and only add non-null ones
+                    neighborCells
+                            .stream()
+                            .filter(Objects::nonNull)
+                            .forEach(cellInformation -> addCellInformationToView(cellInformation));
                 }
             }
             updateUIHandler.postDelayed(updateUI, 500);

--- a/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/SettingPreferences/LoggingSettingsFragment.java
+++ b/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/SettingPreferences/LoggingSettingsFragment.java
@@ -14,6 +14,7 @@ import android.text.InputType;
 import android.util.Log;
 
 import androidx.preference.PreferenceFragmentCompat;
+import androidx.preference.PreferenceScreen;
 import androidx.preference.SwitchPreferenceCompat;
 
 import de.fraunhofer.fokus.OpenMobileNetworkToolkit.R;
@@ -48,6 +49,18 @@ public class LoggingSettingsFragment extends PreferenceFragmentCompat
         if (s.equals("enable_logging")) {
             boolean logger = sharedPreferences.getBoolean("enable_logging", false);
             Log.d(TAG, "Logger update: " + logger);
+        }
+    }
+
+    @Override
+    public void onDestroyView() {
+        super.onDestroyView();
+        PreferenceScreen prefScreen = getPreferenceScreen();
+        if (prefScreen != null) {
+            SharedPreferences prefsSharedPref = prefScreen.getSharedPreferences();
+            if (prefsSharedPref != null) {
+                prefsSharedPref.unregisterOnSharedPreferenceChangeListener(this);
+            }
         }
     }
 }

--- a/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/cloudCity/NetworkClient.java
+++ b/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/cloudCity/NetworkClient.java
@@ -38,7 +38,7 @@ public class NetworkClient {
                             return null;
                         }
 
-                        if (!url.equalsIgnoreCase(currentClientBaseUrl)) {
+                        if (!baseUrl.equalsIgnoreCase(currentClientBaseUrl)) {
                             Log.w(TAG, "URL has changed from previous Retrofit client's base URL, instantiating new client...");
                         }
 

--- a/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/cloudCity/NetworkClient.java
+++ b/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/cloudCity/NetworkClient.java
@@ -1,33 +1,66 @@
 package de.fraunhofer.fokus.OpenMobileNetworkToolkit.cloudCity;
 
+import android.util.Log;
+
 import java.util.Locale;
+import java.util.concurrent.locks.ReentrantLock;
 
 import retrofit2.Retrofit;
 import retrofit2.converter.gson.GsonConverterFactory;
 
 public class NetworkClient {
+    private static final String TAG = "NetworkClient";
 
-    private static Retrofit retrofit;
+    private static volatile Retrofit retrofit;
+    private static volatile String currentClientBaseUrl;
+    private static ReentrantLock lock = new ReentrantLock();
+    private static final Object lockObject = new Object();
 
     /**
-     * Get retrofit client to be used for the communication. Creates singleton.
+     * Get retrofit client to be used for the communication. Creates and memoizes the client which will
+     * be reused as long as the URL stays the same - when the URL changes and differs from what the
+     * memoized ("singleton") client was initialized with - a new client gets initialized with the new base URL.
+     *
      * @return Instance of retrofit client to be used.
      */
-    public static Retrofit getRetrofitClient(String url) {
-        if (retrofit == null) {
-            if (url == null || url.isEmpty()){
-                return null;
+    public static synchronized Retrofit getRetrofitClient(String url) {
+        String baseUrl = String.format(Locale.US, "https://%s/", url);
+        // If we don't have a retrofit client, or the URL we're targetting is different
+        // than what the previous client was initialized with - build a new client;
+        // otherwise return the last initialized one
+        boolean isLocked = false;
+        try {
+            isLocked = lock.tryLock();
+            if (isLocked) {
+                synchronized (lockObject) {
+                    if (retrofit == null || !baseUrl.equalsIgnoreCase(currentClientBaseUrl)) {
+                        if (url == null || url.isEmpty()) {
+                            return null;
+                        }
+
+                        if (!url.equalsIgnoreCase(currentClientBaseUrl)) {
+                            Log.w(TAG, "URL has changed from previous Retrofit client's base URL, instantiating new client...");
+                        }
+
+                        retrofit = new Retrofit.Builder()
+                                .baseUrl(baseUrl)
+                                .client(CustomClient.getUnsafeOkHttpClient())
+                                .addConverterFactory(GsonConverterFactory.create())
+                                .build();
+                        currentClientBaseUrl = baseUrl;
+                    }
+
+                    return retrofit;
+                }
             }
-
-            String baseUrl = String.format(Locale.US, "https://%s/", url);
-
-            retrofit = new Retrofit.Builder()
-                    .baseUrl(baseUrl)
-                    .client(CustomClient.getUnsafeOkHttpClient())
-                    .addConverterFactory(GsonConverterFactory.create())
-                    .build();
+        } finally {
+            // The finally is executed always, so even though we return in the locked part, it will still unlock
+            if (isLocked) {
+                lock.unlock();
+            }
         }
 
+        // Return null otherwise if we couldn't lock and initialize, or rather return whatever we had before...
         return retrofit;
     }
 }


### PR DESCRIPTION
This PR was supposed to just do the Iperf3 runner part, so we can easily programatically start the Iperf3 test, but once that part was done... the whole tying up part was also done and the feature was completed on this branch.

Could use a review and probably some more cleaning up but for now, it works, and seems stable.

Oh right - it's still lacking the whole "sending to the server" part, which can be done in a PR of it's own.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a speed monitoring feature in GPS monitoring, triggering tests based on speed thresholds.
	- Added a new method to initiate a default 15-second Iperf3 test.
	- Implemented a reusable TimerWrapper class for enhanced task scheduling.

- **Enhancements**
	- Improved thread safety in parameter management and listener handling.
	- Enhanced logging and error handling in various components for better visibility.

- **Bug Fixes**
	- Filtered out null entries in cell information lists to prevent UI issues.

- **Lifecycle Management**
	- Added proper listener unregistration in `LoggingSettingsFragment` to prevent memory leaks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->