### PR TITLE
Iperf3 serialization

### DIFF
--- a/app/src/main/java/cloudcity/CloudCityOMNTApplication.java
+++ b/app/src/main/java/cloudcity/CloudCityOMNTApplication.java
@@ -3,6 +3,8 @@ package cloudcity;
 import android.app.Application;
 
 import cloudcity.dataholders.MetricsPOJO;
+import de.fraunhofer.fokus.OpenMobileNetworkToolkit.DataProvider.DataProvider;
+import de.fraunhofer.fokus.OpenMobileNetworkToolkit.GlobalVars;
 
 public class CloudCityOMNTApplication extends Application {
     public static final String TAG = CloudCityOMNTApplication.class.getSimpleName();
@@ -21,6 +23,9 @@ public class CloudCityOMNTApplication extends Application {
             @Override
             public void onIperf3TestCompleted(MetricsPOJO metrics) {
                 android.util.Log.wtf(TAG, "One iperf3 cycle is completed! received metrics: "+metrics);
+                DataProvider dp = GlobalVars.getInstance().get_dp();
+                boolean iperf3SendingResult = CloudCityUtil.sendIperf3Data(metrics, dp.getLocation());
+                android.util.Log.d(TAG, "sending metrics result: "+iperf3SendingResult);
             }
         });
     }

--- a/app/src/main/java/cloudcity/CloudCityOMNTApplication.java
+++ b/app/src/main/java/cloudcity/CloudCityOMNTApplication.java
@@ -17,5 +17,16 @@ public class CloudCityOMNTApplication extends Application {
         CloudCityParamsRepository.initialize(getApplicationContext());
 
         Iperf3Monitor.initialize(getApplicationContext());
+        iperf3Monitor = Iperf3Monitor.getInstance();
+
+        iperf3Monitor.startListeningForIperf3Updates(new Iperf3Monitor.Iperf3MonitorCompletionListener() {
+            @Override
+            public void onIperf3TestCompleted(MetricsPOJO metrics) {
+                android.util.Log.wtf(TAG, "One iperf3 cycle is completed! received metrics: "+metrics);
+                DataProvider dp = GlobalVars.getInstance().get_dp();
+                boolean iperf3SendingResult = CloudCityUtil.sendIperf3Data(metrics, dp.getLocation());
+                android.util.Log.d(TAG, "sending metrics result: "+iperf3SendingResult);
+            }
+        });
     }
 }

--- a/app/src/main/java/cloudcity/CloudCityOMNTApplication.java
+++ b/app/src/main/java/cloudcity/CloudCityOMNTApplication.java
@@ -17,16 +17,5 @@ public class CloudCityOMNTApplication extends Application {
         CloudCityParamsRepository.initialize(getApplicationContext());
 
         Iperf3Monitor.initialize(getApplicationContext());
-        iperf3Monitor = Iperf3Monitor.getInstance();
-
-        iperf3Monitor.startListeningForIperf3Updates(new Iperf3Monitor.Iperf3MonitorCompletionListener() {
-            @Override
-            public void onIperf3TestCompleted(MetricsPOJO metrics) {
-                android.util.Log.wtf(TAG, "One iperf3 cycle is completed! received metrics: "+metrics);
-                DataProvider dp = GlobalVars.getInstance().get_dp();
-                boolean iperf3SendingResult = CloudCityUtil.sendIperf3Data(metrics, dp.getLocation());
-                android.util.Log.d(TAG, "sending metrics result: "+iperf3SendingResult);
-            }
-        });
     }
 }

--- a/app/src/main/java/cloudcity/CloudCityUtil.java
+++ b/app/src/main/java/cloudcity/CloudCityUtil.java
@@ -4,6 +4,13 @@ import android.os.Build;
 
 import androidx.annotation.NonNull;
 
+import cloudcity.dataholders.MetricsPOJO;
+import cloudcity.networking.CloudCityHelpers;
+import cloudcity.networking.models.Iperf3NetworkDataModel;
+import cloudcity.networking.models.NetworkDataModel;
+import cloudcity.networking.models.NetworkDataModelRequest;
+import de.fraunhofer.fokus.OpenMobileNetworkToolkit.DataProvider.LocationInformation;
+
 public class CloudCityUtil {
 
     /**
@@ -23,5 +30,22 @@ public class CloudCityUtil {
 
     private static boolean isBlank_pre34(@NonNull String param) {
         return param.trim().isEmpty();
+    }
+
+    public static boolean sendIperf3Data(MetricsPOJO metricsPOJO, LocationInformation location) {
+        MetricsPOJO.MetricsPair metricsPair = metricsPOJO.toMetricsPair();
+        MetricsPOJO.UploadMetrics uploadMetrics = metricsPair.getUploadMetrics();
+        MetricsPOJO.DownloadMetrics downloadMetrics = metricsPair.getDownloadMetrics();
+
+        Iperf3NetworkDataModel iperf3Data = new Iperf3NetworkDataModel(uploadMetrics, downloadMetrics, location);
+        return CloudCityUtil.sendIperf3Data(iperf3Data);
+    }
+
+    private static boolean sendIperf3Data(NetworkDataModel data) {
+        String address = CloudCityParamsRepository.getInstance().getServerUrl();
+        String token = CloudCityParamsRepository.getInstance().getServerToken();
+        NetworkDataModelRequest requestData = new NetworkDataModelRequest();
+        requestData.add(data);
+        return CloudCityHelpers.sendData(address, token, requestData);
     }
 }

--- a/app/src/main/java/cloudcity/LoggingServiceExtensions.java
+++ b/app/src/main/java/cloudcity/LoggingServiceExtensions.java
@@ -173,6 +173,7 @@ public class LoggingServiceExtensions {
 
         String category = currentCell.getCellType().toString();
 
+        //TODO SHARK replace this location with GPSMonitor's location
         MobileSignalNetworkDataModel dataModel = new MobileSignalNetworkDataModel(
                 location,
                 getMeasurementsModel(category, currentCell)

--- a/app/src/main/java/cloudcity/LoggingServiceExtensions.java
+++ b/app/src/main/java/cloudcity/LoggingServiceExtensions.java
@@ -4,7 +4,6 @@ import android.content.SharedPreferences;
 import android.graphics.Color;
 import android.os.Handler;
 import android.os.HandlerThread;
-import android.os.Looper;
 import android.telephony.CellInfo;
 import android.util.Log;
 import android.widget.ImageView;
@@ -24,11 +23,11 @@ import de.fraunhofer.fokus.OpenMobileNetworkToolkit.DataProvider.LocationInforma
 import de.fraunhofer.fokus.OpenMobileNetworkToolkit.GlobalVars;
 import de.fraunhofer.fokus.OpenMobileNetworkToolkit.Preferences.SPType;
 import de.fraunhofer.fokus.OpenMobileNetworkToolkit.Preferences.SharedPreferencesGrouper;
-import de.fraunhofer.fokus.OpenMobileNetworkToolkit.cloudCity.CloudCityHelpers;
-import de.fraunhofer.fokus.OpenMobileNetworkToolkit.cloudCity.models.CellInfoModel;
-import de.fraunhofer.fokus.OpenMobileNetworkToolkit.cloudCity.models.MeasurementsModel;
-import de.fraunhofer.fokus.OpenMobileNetworkToolkit.cloudCity.models.NetworkDataModel;
-import de.fraunhofer.fokus.OpenMobileNetworkToolkit.cloudCity.models.NetworkDataModelRequest;
+import cloudcity.networking.CloudCityHelpers;
+import cloudcity.networking.models.CellInfoModel;
+import cloudcity.networking.models.MeasurementsModel;
+import cloudcity.networking.models.NetworkDataModel;
+import cloudcity.networking.models.NetworkDataModelRequest;
 
 public class LoggingServiceExtensions {
     private static final String TAG = "LoggingServiceExtensions";

--- a/app/src/main/java/cloudcity/LoggingServiceExtensions.java
+++ b/app/src/main/java/cloudcity/LoggingServiceExtensions.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import cloudcity.networking.models.MobileSignalNetworkDataModel;
 import de.fraunhofer.fokus.OpenMobileNetworkToolkit.DataProvider.CellInformations.CellInformation;
 import de.fraunhofer.fokus.OpenMobileNetworkToolkit.DataProvider.CellInformations.GSMInformation;
 import de.fraunhofer.fokus.OpenMobileNetworkToolkit.DataProvider.CellInformations.LTEInformation;
@@ -172,7 +173,7 @@ public class LoggingServiceExtensions {
 
         String category = currentCell.getCellType().toString();
 
-        NetworkDataModel dataModel = new NetworkDataModel();
+        MobileSignalNetworkDataModel dataModel = new MobileSignalNetworkDataModel();
 
         dataModel.setCategory(currentCell.getCellType().toString());
         dataModel.setLatitude(location.getLatitude());

--- a/app/src/main/java/cloudcity/LoggingServiceExtensions.java
+++ b/app/src/main/java/cloudcity/LoggingServiceExtensions.java
@@ -173,17 +173,17 @@ public class LoggingServiceExtensions {
 
         String category = currentCell.getCellType().toString();
 
-        MobileSignalNetworkDataModel dataModel = new MobileSignalNetworkDataModel();
+        MobileSignalNetworkDataModel dataModel = new MobileSignalNetworkDataModel(
+                location,
+                getMeasurementsModel(category, currentCell)
+        );
 
         dataModel.setCategory(currentCell.getCellType().toString());
-        dataModel.setLatitude(location.getLatitude());
-        dataModel.setLongitude(location.getLongitude());
         dataModel.setAccuracy(location.getAccuracy());
         /* Convert to km/h */
         dataModel.setSpeed(location.getSpeed() * 3.6);
 
         dataModel.setCellData(getCellInfoModel(category, currentCell));
-        dataModel.setValues(getMeasurementsModel(category, currentCell));
 
         return dataModel;
     }

--- a/app/src/main/java/cloudcity/MainActivityExtensions.java
+++ b/app/src/main/java/cloudcity/MainActivityExtensions.java
@@ -87,4 +87,26 @@ public class MainActivityExtensions {
         gpsMonitor = new GPSMonitor(applicationContext);
         gpsMonitor.startMonitoring();
     }
+
+    /**
+     * TODO SHARK Figure out how to make this one work
+     */
+    /*
+    public static void startListeningToIperf3ResultsAndUploadOnSuccess() {
+        Log.d(TAG, "--> startListeningToIperf3ResultsAndUploadOnSuccess()");
+        iperf3Monitor = Iperf3Monitor.getInstance();
+
+        iperf3Monitor.startListeningForIperf3Updates(new Iperf3Monitor.Iperf3MonitorCompletionListener() {
+            @Override
+            public void onIperf3TestCompleted(MetricsPOJO metrics) {
+                Log.wtf(TAG, "One iperf3 cycle is completed! received metrics: "+metrics);
+                DataProvider dp = GlobalVars.getInstance().get_dp();
+                //TODO SHARK replace this location with GPSMonitor's location
+                boolean iperf3SendingResult = CloudCityUtil.sendIperf3Data(metrics, dp.getLocation());
+                Log.wtf(TAG, "sending iperf3 metrics result: "+iperf3SendingResult);
+            }
+        });
+        Log.d(TAG, "<-- startListeningToIperf3ResultsAndUploadOnSuccess()");
+    }
+     */
 }

--- a/app/src/main/java/cloudcity/MainActivityExtensions.java
+++ b/app/src/main/java/cloudcity/MainActivityExtensions.java
@@ -9,17 +9,12 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.util.Log;
 
-import cloudcity.dataholders.MetricsPOJO;
 import de.fraunhofer.fokus.OpenMobileNetworkToolkit.DataProvider.DataProvider;
-import de.fraunhofer.fokus.OpenMobileNetworkToolkit.GlobalVars;
 import de.fraunhofer.fokus.OpenMobileNetworkToolkit.Preferences.SPType;
 import de.fraunhofer.fokus.OpenMobileNetworkToolkit.Preferences.SharedPreferencesGrouper;
 
 public class MainActivityExtensions {
-    private static final String TAG = "MainActivityExtensions";
-
     private static GPSMonitor gpsMonitor;
-    private static Iperf3Monitor iperf3Monitor;
 
     /**
      * We will be using the 'logging' shared pref since that's the only one that is displayed in the logging settings fragment...
@@ -91,21 +86,5 @@ public class MainActivityExtensions {
         // GPSMonitor
         gpsMonitor = new GPSMonitor(applicationContext);
         gpsMonitor.startMonitoring();
-    }
-
-    public static void startListeningToIperf3ResultsAndUploadOnSuccess() {
-        Log.d(TAG, "--> startListeningToIperf3ResultsAndUploadOnSuccess()");
-        iperf3Monitor = Iperf3Monitor.getInstance();
-
-        iperf3Monitor.startListeningForIperf3Updates(new Iperf3Monitor.Iperf3MonitorCompletionListener() {
-            @Override
-            public void onIperf3TestCompleted(MetricsPOJO metrics) {
-                Log.wtf(TAG, "One iperf3 cycle is completed! received metrics: "+metrics);
-                DataProvider dp = GlobalVars.getInstance().get_dp();
-                boolean iperf3SendingResult = CloudCityUtil.sendIperf3Data(metrics, dp.getLocation());
-                Log.wtf(TAG, "sending metrics result: "+iperf3SendingResult);
-            }
-        });
-        Log.d(TAG, "<-- startListeningToIperf3ResultsAndUploadOnSuccess()");
     }
 }

--- a/app/src/main/java/cloudcity/dataholders/MetricsPOJO.java
+++ b/app/src/main/java/cloudcity/dataholders/MetricsPOJO.java
@@ -2,8 +2,6 @@ package cloudcity.dataholders;
 
 import androidx.annotation.NonNull;
 
-import com.google.gson.annotations.SerializedName;
-
 /**
  * Plain Old Java Object (POJO) for holding iPerf3 network performance metrics.
  * Contains statistical data for both download (DL) and upload (UL) measurements.

--- a/app/src/main/java/cloudcity/dataholders/MetricsPOJO.java
+++ b/app/src/main/java/cloudcity/dataholders/MetricsPOJO.java
@@ -1,5 +1,9 @@
 package cloudcity.dataholders;
 
+import androidx.annotation.NonNull;
+
+import com.google.gson.annotations.SerializedName;
+
 /**
  * Plain Old Java Object (POJO) for holding iPerf3 network performance metrics.
  * Contains statistical data for both download (DL) and upload (UL) measurements.
@@ -69,6 +73,28 @@ public class MetricsPOJO {
         );
     }
 
+    public MetricsPair toMetricsPair() {
+        return new MetricsPair(
+                new UploadMetrics(ULmin, ULmedian, ULmean, ULmax, ULlast),
+                new DownloadMetrics(DLmin, DLmedian, DLmean, DLmax, DLlast)
+        );
+    }
+
+    public static class MetricsPair {
+        @NonNull
+        final UploadMetrics uploadMetrics;
+        @NonNull
+        final DownloadMetrics downloadMetrics;
+
+        MetricsPair(@NonNull UploadMetrics upload, @NonNull DownloadMetrics download) {
+            this.uploadMetrics = upload;
+            this.downloadMetrics = download;
+        }
+
+        public @NonNull UploadMetrics getUploadMetrics() { return uploadMetrics; }
+        public @NonNull DownloadMetrics getDownloadMetrics() { return downloadMetrics; }
+    }
+
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();
@@ -104,6 +130,26 @@ public class MetricsPOJO {
             this.DLmax = DLmax;
             this.DLlast = DLlast;
         }
+
+        public double getDLmin() {
+            return DLmin;
+        }
+
+        public double getDLmedian() {
+            return DLmedian;
+        }
+
+        public double getDLmean() {
+            return DLmean;
+        }
+
+        public double getDLmax() {
+            return DLmax;
+        }
+
+        public double getDLlast() {
+            return DLlast;
+        }
     }
 
     public static class UploadMetrics {
@@ -119,6 +165,26 @@ public class MetricsPOJO {
             this.ULmean = ULmean;
             this.ULmax = ULmax;
             this.ULlast = ULlast;
+        }
+
+        public double getULmin() {
+            return ULmin;
+        }
+
+        public double getULmedian() {
+            return ULmedian;
+        }
+
+        public double getULmean() {
+            return ULmean;
+        }
+
+        public double getULmax() {
+            return ULmax;
+        }
+
+        public double getULlast() {
+            return ULlast;
         }
     }
 }

--- a/app/src/main/java/cloudcity/networking/CloudCityHelpers.java
+++ b/app/src/main/java/cloudcity/networking/CloudCityHelpers.java
@@ -1,11 +1,11 @@
-package de.fraunhofer.fokus.OpenMobileNetworkToolkit.cloudCity;
+package cloudcity.networking;
 
 import android.util.Log;
 
 import java.io.IOException;
 import java.util.Locale;
 
-import de.fraunhofer.fokus.OpenMobileNetworkToolkit.cloudCity.models.NetworkDataModelRequest;
+import cloudcity.networking.models.NetworkDataModelRequest;
 import retrofit2.Response;
 import retrofit2.Retrofit;
 

--- a/app/src/main/java/cloudcity/networking/CustomClient.java
+++ b/app/src/main/java/cloudcity/networking/CustomClient.java
@@ -1,4 +1,4 @@
-package de.fraunhofer.fokus.OpenMobileNetworkToolkit.cloudCity;
+package cloudcity.networking;
 
 import java.security.SecureRandom;
 import java.util.concurrent.TimeUnit;

--- a/app/src/main/java/cloudcity/networking/CustomTrustManager.java
+++ b/app/src/main/java/cloudcity/networking/CustomTrustManager.java
@@ -1,4 +1,4 @@
-package de.fraunhofer.fokus.OpenMobileNetworkToolkit.cloudCity;
+package cloudcity.networking;
 
 import javax.net.ssl.X509TrustManager;
 import java.security.cert.CertificateException;

--- a/app/src/main/java/cloudcity/networking/NetworkClient.java
+++ b/app/src/main/java/cloudcity/networking/NetworkClient.java
@@ -1,4 +1,4 @@
-package de.fraunhofer.fokus.OpenMobileNetworkToolkit.cloudCity;
+package cloudcity.networking;
 
 import android.util.Log;
 

--- a/app/src/main/java/cloudcity/networking/ServerAPI.java
+++ b/app/src/main/java/cloudcity/networking/ServerAPI.java
@@ -1,6 +1,6 @@
-package de.fraunhofer.fokus.OpenMobileNetworkToolkit.cloudCity;
+package cloudcity.networking;
 
-import de.fraunhofer.fokus.OpenMobileNetworkToolkit.cloudCity.models.NetworkDataModelRequest;
+import cloudcity.networking.models.NetworkDataModelRequest;
 import retrofit2.Call;
 import retrofit2.http.Body;
 import retrofit2.http.Header;

--- a/app/src/main/java/cloudcity/networking/models/CellInfoModel.java
+++ b/app/src/main/java/cloudcity/networking/models/CellInfoModel.java
@@ -1,4 +1,4 @@
-package de.fraunhofer.fokus.OpenMobileNetworkToolkit.cloudCity.models;
+package cloudcity.networking.models;
 
 import com.google.gson.annotations.SerializedName;
 import android.telephony.CellInfo;

--- a/app/src/main/java/cloudcity/networking/models/Iperf3NetworkDataModel.java
+++ b/app/src/main/java/cloudcity/networking/models/Iperf3NetworkDataModel.java
@@ -1,0 +1,79 @@
+package cloudcity.networking.models;
+
+import androidx.annotation.NonNull;
+
+import com.google.gson.annotations.SerializedName;
+
+import cloudcity.dataholders.MetricsPOJO;
+import de.fraunhofer.fokus.OpenMobileNetworkToolkit.DataProvider.LocationInformation;
+
+public class Iperf3NetworkDataModel extends NetworkDataModel {
+
+    @SerializedName("category")
+    final private String category = "Iperf3";
+
+    @SerializedName("lat")
+    private double latitude;
+    @SerializedName("lon")
+    private double longitude;
+
+    @SerializedName("accuracy")
+    private double accuracy;
+    @SerializedName("speed")
+    private double speed;
+
+    @SerializedName("values")
+    final private Iperf3ValuesModel values;
+
+
+    public Iperf3NetworkDataModel(
+            MetricsPOJO.UploadMetrics upload,
+            MetricsPOJO.DownloadMetrics download,
+            LocationInformation location
+    ) {
+        this.values = new Iperf3ValuesModel(upload, download);
+        this.latitude = location.getLatitude();
+        this.longitude = location.getLongitude();
+        this.accuracy = location.getAccuracy();
+        this.speed = location.getSpeed();
+    }
+}
+
+class Iperf3ValuesModel {
+    @SerializedName("upload_min")
+    private final double ULmin;
+    @SerializedName("upload_median")
+    private final double ULmedian;
+    @SerializedName("upload_mean")
+    private final double ULmean;
+    @SerializedName("upload_max")
+    private final double ULmax;
+    @SerializedName("upload_last")
+    private final double ULlast;
+
+    @SerializedName("download_min")
+    private final double DLmin;
+    @SerializedName("download_median")
+    private final double DLmedian;
+    @SerializedName("download_mean")
+    private final double DLmean;
+    @SerializedName("download_max")
+    private final double DLmax;
+    @SerializedName("download_last")
+    private final double DLlast;
+
+    public Iperf3ValuesModel(@NonNull MetricsPOJO.UploadMetrics upload,
+                             @NonNull MetricsPOJO.DownloadMetrics download) {
+        ULmin = upload.getULmin();
+        ULmedian = upload.getULmedian();
+        ULmean = upload.getULmean();
+        ULmax = upload.getULmax();
+        ULlast = upload.getULlast();
+
+        DLmin = download.getDLmin();
+        DLmedian = download.getDLmedian();
+        DLmean = download.getDLmean();
+        DLmax = download.getDLmax();
+        DLlast = download.getDLlast();
+    }
+}

--- a/app/src/main/java/cloudcity/networking/models/Iperf3NetworkDataModel.java
+++ b/app/src/main/java/cloudcity/networking/models/Iperf3NetworkDataModel.java
@@ -12,34 +12,23 @@ public class Iperf3NetworkDataModel extends NetworkDataModel {
     @SerializedName("category")
     final private String category = "Iperf3";
 
-    @SerializedName("lat")
-    private double latitude;
-    @SerializedName("lon")
-    private double longitude;
-
     @SerializedName("accuracy")
     private double accuracy;
     @SerializedName("speed")
     private double speed;
 
-    @SerializedName("values")
-    final private Iperf3ValuesModel values;
-
-
     public Iperf3NetworkDataModel(
-            MetricsPOJO.UploadMetrics upload,
-            MetricsPOJO.DownloadMetrics download,
-            LocationInformation location
+            @NonNull MetricsPOJO.UploadMetrics upload,
+            @NonNull MetricsPOJO.DownloadMetrics download,
+            @NonNull LocationInformation location
     ) {
-        this.values = new Iperf3ValuesModel(upload, download);
-        this.latitude = location.getLatitude();
-        this.longitude = location.getLongitude();
+        super(location.getLatitude(), location.getLongitude(), new Iperf3ValuesModel(upload, download));
         this.accuracy = location.getAccuracy();
         this.speed = location.getSpeed();
     }
 }
 
-class Iperf3ValuesModel {
+class Iperf3ValuesModel extends NetworkDataModel.NetworkDataModelValues {
     @SerializedName("upload_min")
     private final double ULmin;
     @SerializedName("upload_median")

--- a/app/src/main/java/cloudcity/networking/models/MeasurementsModel.java
+++ b/app/src/main/java/cloudcity/networking/models/MeasurementsModel.java
@@ -4,7 +4,7 @@ import android.telephony.CellInfo;
 
 import com.google.gson.annotations.SerializedName;
 
-public class MeasurementsModel {
+public class MeasurementsModel extends NetworkDataModel.NetworkDataModelValues {
 
     // LTE
     private Integer rsrp;

--- a/app/src/main/java/cloudcity/networking/models/MeasurementsModel.java
+++ b/app/src/main/java/cloudcity/networking/models/MeasurementsModel.java
@@ -1,4 +1,4 @@
-package de.fraunhofer.fokus.OpenMobileNetworkToolkit.cloudCity.models;
+package cloudcity.networking.models;
 
 import android.telephony.CellInfo;
 

--- a/app/src/main/java/cloudcity/networking/models/MobileSignalNetworkDataModel.java
+++ b/app/src/main/java/cloudcity/networking/models/MobileSignalNetworkDataModel.java
@@ -1,0 +1,86 @@
+package cloudcity.networking.models;
+
+import com.google.gson.annotations.SerializedName;
+
+public class MobileSignalNetworkDataModel extends NetworkDataModel {
+
+    private String category;
+    @SerializedName("lat")
+    private double latitude;
+    @SerializedName("lon")
+    private double longitude;
+    private double accuracy;
+    private double speed;
+    @SerializedName("cell_info")
+    private CellInfoModel cellData;
+    private MeasurementsModel values;
+
+    public String getCategory() {
+        return category;
+    }
+
+    public void setCategory(String category) {
+        this.category = category;
+    }
+
+    public double getLatitude() {
+        return latitude;
+    }
+
+    public void setLatitude(double latitude) {
+        this.latitude = latitude;
+    }
+
+    public double getLongitude() {
+        return longitude;
+    }
+
+    public void setLongitude(double longitude) {
+        this.longitude = longitude;
+    }
+
+    public double getAccuracy() {
+        return accuracy;
+    }
+
+    public void setAccuracy(double accuracy) {
+        this.accuracy = accuracy;
+    }
+
+    public double getSpeed() {
+        return speed;
+    }
+
+    public void setSpeed(double speed) {
+        this.speed = speed;
+    }
+
+    public CellInfoModel getCellData() {
+        return cellData;
+    }
+
+    public void setCellData(CellInfoModel cellData) {
+        this.cellData = cellData;
+    }
+
+    public MeasurementsModel getValues() {
+        return values;
+    }
+
+    public void setValues(MeasurementsModel values) {
+        this.values = values;
+    }
+
+    @Override
+    public String toString() {
+        return "NetworkDataModel{" +
+                "category='" + category + '\'' +
+                ", latitude=" + latitude +
+                ", longitude=" + longitude +
+                ", accuracy=" + accuracy +
+                ", speed=" + speed +
+                ", cellData=" + cellData +
+                ", values=" + values +
+                '}';
+    }
+}

--- a/app/src/main/java/cloudcity/networking/models/MobileSignalNetworkDataModel.java
+++ b/app/src/main/java/cloudcity/networking/models/MobileSignalNetworkDataModel.java
@@ -1,19 +1,22 @@
 package cloudcity.networking.models;
 
+import androidx.annotation.NonNull;
+
 import com.google.gson.annotations.SerializedName;
+
+import de.fraunhofer.fokus.OpenMobileNetworkToolkit.DataProvider.LocationInformation;
 
 public class MobileSignalNetworkDataModel extends NetworkDataModel {
 
     private String category;
-    @SerializedName("lat")
-    private double latitude;
-    @SerializedName("lon")
-    private double longitude;
     private double accuracy;
     private double speed;
     @SerializedName("cell_info")
     private CellInfoModel cellData;
-    private MeasurementsModel values;
+
+    public MobileSignalNetworkDataModel(@NonNull LocationInformation locationInformation, @NonNull MeasurementsModel values) {
+        super(locationInformation.getLatitude(), locationInformation.getLongitude(), values);
+    }
 
     public String getCategory() {
         return category;
@@ -27,16 +30,8 @@ public class MobileSignalNetworkDataModel extends NetworkDataModel {
         return latitude;
     }
 
-    public void setLatitude(double latitude) {
-        this.latitude = latitude;
-    }
-
     public double getLongitude() {
         return longitude;
-    }
-
-    public void setLongitude(double longitude) {
-        this.longitude = longitude;
     }
 
     public double getAccuracy() {
@@ -63,13 +58,6 @@ public class MobileSignalNetworkDataModel extends NetworkDataModel {
         this.cellData = cellData;
     }
 
-    public MeasurementsModel getValues() {
-        return values;
-    }
-
-    public void setValues(MeasurementsModel values) {
-        this.values = values;
-    }
 
     @Override
     public String toString() {

--- a/app/src/main/java/cloudcity/networking/models/NetworkDataModel.java
+++ b/app/src/main/java/cloudcity/networking/models/NetworkDataModel.java
@@ -2,85 +2,9 @@ package cloudcity.networking.models;
 
 import com.google.gson.annotations.SerializedName;
 
+/**
+ * Base class for our network data
+ */
 public class NetworkDataModel {
 
-    private String category;
-    @SerializedName("lat")
-    private double latitude;
-    @SerializedName("lon")
-    private double longitude;
-    private double accuracy;
-    private double speed;
-    @SerializedName("cell_info")
-    private CellInfoModel cellData;
-    private MeasurementsModel values;
-
-    public String getCategory() {
-        return category;
-    }
-
-    public void setCategory(String category) {
-        this.category = category;
-    }
-
-    public double getLatitude() {
-        return latitude;
-    }
-
-    public void setLatitude(double latitude) {
-        this.latitude = latitude;
-    }
-
-    public double getLongitude() {
-        return longitude;
-    }
-
-    public void setLongitude(double longitude) {
-        this.longitude = longitude;
-    }
-
-    public double getAccuracy() {
-        return accuracy;
-    }
-
-    public void setAccuracy(double accuracy) {
-        this.accuracy = accuracy;
-    }
-
-    public double getSpeed() {
-        return speed;
-    }
-
-    public void setSpeed(double speed) {
-        this.speed = speed;
-    }
-
-    public CellInfoModel getCellData() {
-        return cellData;
-    }
-
-    public void setCellData(CellInfoModel cellData) {
-        this.cellData = cellData;
-    }
-
-    public MeasurementsModel getValues() {
-        return values;
-    }
-
-    public void setValues(MeasurementsModel values) {
-        this.values = values;
-    }
-
-    @Override
-    public String toString() {
-        return "NetworkDataModel{" +
-                "category='" + category + '\'' +
-                ", latitude=" + latitude +
-                ", longitude=" + longitude +
-                ", accuracy=" + accuracy +
-                ", speed=" + speed +
-                ", cellData=" + cellData +
-                ", values=" + values +
-                '}';
-    }
 }

--- a/app/src/main/java/cloudcity/networking/models/NetworkDataModel.java
+++ b/app/src/main/java/cloudcity/networking/models/NetworkDataModel.java
@@ -6,5 +6,18 @@ import com.google.gson.annotations.SerializedName;
  * Base class for our network data
  */
 public class NetworkDataModel {
+    @SerializedName("lat")
+    protected final double latitude;
+    @SerializedName("lon")
+    protected final double longitude;
+    @SerializedName("values")
+    protected final NetworkDataModelValues values;
 
+    public NetworkDataModel(double latitude, double longitude, NetworkDataModelValues values) {
+        this.latitude = latitude;
+        this.longitude = longitude;
+        this.values = values;
+    }
+
+    static class NetworkDataModelValues { }
 }

--- a/app/src/main/java/cloudcity/networking/models/NetworkDataModel.java
+++ b/app/src/main/java/cloudcity/networking/models/NetworkDataModel.java
@@ -1,4 +1,4 @@
-package de.fraunhofer.fokus.OpenMobileNetworkToolkit.cloudCity.models;
+package cloudcity.networking.models;
 
 import com.google.gson.annotations.SerializedName;
 

--- a/app/src/main/java/cloudcity/networking/models/NetworkDataModelRequest.java
+++ b/app/src/main/java/cloudcity/networking/models/NetworkDataModelRequest.java
@@ -1,4 +1,4 @@
-package de.fraunhofer.fokus.OpenMobileNetworkToolkit.cloudCity.models;
+package cloudcity.networking.models;
 
 import com.google.gson.annotations.SerializedName;
 

--- a/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/MainActivity.java
+++ b/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/MainActivity.java
@@ -355,7 +355,6 @@ public class MainActivity extends AppCompatActivity implements PreferenceFragmen
                         );
 
                 // Start GPS monitoring
-                //TODO tie in GPS monitoring with the yet-to-happen Iperf3Starter and ideally move that to IperfMonitor
                 MainActivityExtensions
                         .startGPSMonitoring(getApplicationContext());
             }

--- a/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/MainActivity.java
+++ b/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/MainActivity.java
@@ -357,9 +357,6 @@ public class MainActivity extends AppCompatActivity implements PreferenceFragmen
                 // Start GPS monitoring
                 MainActivityExtensions
                         .startGPSMonitoring(getApplicationContext());
-
-                MainActivityExtensions
-                        .startListeningToIperf3ResultsAndUploadOnSuccess();
             }
         }
         Log.d(TAG, "<-- onRequestPermissionsResult()");

--- a/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/MainActivity.java
+++ b/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/MainActivity.java
@@ -357,6 +357,9 @@ public class MainActivity extends AppCompatActivity implements PreferenceFragmen
                 // Start GPS monitoring
                 MainActivityExtensions
                         .startGPSMonitoring(getApplicationContext());
+
+                MainActivityExtensions
+                        .startListeningToIperf3ResultsAndUploadOnSuccess();
             }
         }
         Log.d(TAG, "<-- onRequestPermissionsResult()");


### PR DESCRIPTION
Issue link:
https://github.com/Cloud-City-RS/OMNTelcoMetrics/issues/13

This PR adds the final moving piece of the whole "record upload/download data while standing and upload to our server" by implementing the "upload that data to our server" part, as well as refactoring the previous approach made earlier.

Now, our codebase is entirely separated from OMNT code, apart from where we had to call our extensions, and we can send data successfully by using the `/sensor_event` endpoint

Here's a sample of a nicely formatted request:
```
{
    "sensor_events": [
        {
            "accuracy": 0,
            "category": "Iperf3",
            "lat": 0,
            "lon": 0,
            "speed": 0,
            "values": {
                "download_last": 7.328877851001295,
                "download_max": 7.328877851001295,
                "download_mean": 1.9563004350593993,
                "download_median": 1.0488371900436881,
                "download_min": 0,
                "upload_last": 39.83728285877274,
                "upload_max": 39.83728285877274,
                "upload_mean": 27.326636275436105,
                "upload_median": 25.168920380929126,
                "upload_min": 10.469825501430421
            }
        }
    ]
}
```

receiving a 201 response.