### PR TITLE
Make flavors for different server environments

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -73,8 +73,8 @@ jobs:
         run: | 
           echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
           mkdir upload
-          mv app/build/outputs/apk/debug/*debug*.apk ./upload
-          mv app/build/outputs/apk/release/*release*.apk ./upload
+          mv app/build/outputs/apk/**/debug/*debug*.apk ./upload
+          mv app/build/outputs/apk/**/release/*release*.apk ./upload
           mv app/build/spdx/release.spdx.json ./upload/release.spdx.json
 
       - name: Upload All Artifacts

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -147,7 +147,7 @@ android {
         }
     }
 }
-
+/*
 spdxSbom {
     targets {
         register("release") {
@@ -165,6 +165,50 @@ spdxSbom {
         }
     }
 }
+ */
+
+spdxSbom {
+    targets {
+        // Keep the original release target
+        register("release") {
+            configurations = ['a_stagingReleaseRuntimeClasspath', 'b_demoReleaseRuntimeClasspath', 'c_productionReleaseRuntimeClasspath']
+            scm {
+                uri.set("https://github.com/omnt/OpenMobileNetworkToolkit")
+                revision.set("0.3")
+            }
+            document {
+                name.set("OpenMobileNetworkToolkit")
+                namespace.set("de.fraunhofer.fokus.OpenMobileNetworkToolkit")
+                creator.set("Person: NGNI")
+                packageSupplier.set("Organization: Fraunhofer FOKUS NGNI")
+            }
+        }
+    }
+
+    // And a new thing for all variants
+    android.applicationVariants.configureEach { variant ->
+        def variantName = variant.name
+        println variantName
+        if (variantName != "Release") { // Avoid conflict with the original release target
+            targets {
+                register(variantName) {
+                    configurations = ["${variantName}RuntimeClasspath"]
+                    scm {
+                        uri.set("https://github.com/omnt/OpenMobileNetworkToolkit")
+                        revision.set("0.3")
+                    }
+                    document {
+                        name.set("OpenMobileNetworkToolkit")
+                        namespace.set("de.fraunhofer.fokus.OpenMobileNetworkToolkit")
+                        creator.set("Person: NGNI")
+                        packageSupplier.set("Organization: Fraunhofer FOKUS NGNI")
+                    }
+                }
+            }
+        }
+    }
+}
+
 
 // Sentry
 sentry {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -128,7 +128,22 @@ android {
      */
     applicationVariants.configureEach { variant ->
         variant.outputs.configureEach {
-            outputFileName = "CloudCity_OpenMobileNetworkToolkit_${variant.buildType.name}_${defaultConfig.versionName}.apk"
+            def cleanFlavorName
+            switch (variant.flavorName) {
+                case "a_staging":
+                    cleanFlavorName = "Staging"
+                    break
+                case "b_demo":
+                    cleanFlavorName = "Demo"
+                    break
+                case "c_production":
+                    cleanFlavorName = "Production"
+                    break
+                default:
+                    cleanFlavorName = "Unknown"
+            }
+
+            outputFileName = "CloudCity_OpenMobileNetworkToolkit_${cleanFlavorName}_${variant.buildType.name}_${defaultConfig.versionName}.apk"
         }
     }
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -72,6 +72,34 @@ android {
             signingConfig signingConfigs.debug
         }
     }
+
+    // We'll define the flavor dimensions here, and so far we only have one, for the server environment
+    // this new way of adding dimensions is kinda weird tho
+    flavorDimensions += ["environment"]
+
+    productFlavors {
+        // These are used in CloudCityParamsRepository, which - for now - defines our base server URL and token to use
+        // which can also be altered through the app's settings at runtime
+        staging {
+            dimension "environment"
+            buildConfigField "Boolean", "IS_DEMO", "false"
+            buildConfigField "Boolean", "IS_STAGING", "true"
+            buildConfigField "Boolean", "IS_PRODUCTION", "false"
+        }
+        demo {
+            dimension "environment"
+            buildConfigField "Boolean", "IS_DEMO", "true"
+            buildConfigField "Boolean", "IS_STAGING", "false"
+            buildConfigField "Boolean", "IS_PRODUCTION", "false"
+        }
+        production {
+            dimension "environment"
+            buildConfigField "Boolean", "IS_DEMO", "false"
+            buildConfigField "Boolean", "IS_STAGING", "false"
+            buildConfigField "Boolean", "IS_PRODUCTION", "true"
+        }
+    }
+
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_11
         targetCompatibility JavaVersion.VERSION_11

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -80,19 +80,21 @@ android {
     productFlavors {
         // These are used in CloudCityParamsRepository, which - for now - defines our base server URL and token to use
         // which can also be altered through the app's settings at runtime
-        staging {
+        // The whole a_, b_, c_ thing is so I can control the ordering, since they're lexicographically ordered
+        // and we really don't want to default to the 'demo' flavor...
+        a_staging {
             dimension "environment"
             buildConfigField "Boolean", "IS_DEMO", "false"
             buildConfigField "Boolean", "IS_STAGING", "true"
             buildConfigField "Boolean", "IS_PRODUCTION", "false"
         }
-        demo {
+        b_demo {
             dimension "environment"
             buildConfigField "Boolean", "IS_DEMO", "true"
             buildConfigField "Boolean", "IS_STAGING", "false"
             buildConfigField "Boolean", "IS_PRODUCTION", "false"
         }
-        production {
+        c_production {
             dimension "environment"
             buildConfigField "Boolean", "IS_DEMO", "false"
             buildConfigField "Boolean", "IS_STAGING", "false"

--- a/app/src/main/java/cloudcity/CloudCityParamsRepository.java
+++ b/app/src/main/java/cloudcity/CloudCityParamsRepository.java
@@ -8,8 +8,15 @@ import android.content.SharedPreferences;
 
 import androidx.annotation.Nullable;
 
+import de.fraunhofer.fokus.OpenMobileNetworkToolkit.BuildConfig;
+
+
 public class CloudCityParamsRepository {
     private static final String SHARED_PREFS_NAME = "cloud_city_prefs";
+
+    private static final String STAGING_SERVER_URL = "staging.app.cloudcities.co";
+    private static final String PRODUCTION_SERVER_URL = "app.cloudcities.co";
+    private static final String DEMO_SERVER_URL = "demo.app.cloudcities.co";
 
     private Context context;
     private static CloudCityParamsRepository instance;
@@ -62,11 +69,8 @@ public class CloudCityParamsRepository {
     }
 
     private void prefillWithData() {
-        String sharkToken = "252|GI2CTemW2EX3TmQaDmCzYg1xrs3VEDslnGrfCwp245a84b22";
-        String chungaToken = "68|5LGMoNAd0mck4bmMaGdj2GqjqqYUB1NyqtbSrpFB82303173";
-
-        serverUrl = "staging.app.cloudcities.co";
-        serverToken = sharkToken;
+        serverUrl = getServerURLBasedOnBuildVariant();
+        serverToken = getServerTokenBasedOnBuildVariant();
 
         sharedPrefs
                 .edit()
@@ -150,5 +154,36 @@ public class CloudCityParamsRepository {
                 .edit()
                 .putString(key, value)
                 .commit();
+    }
+
+    private String getServerURLBasedOnBuildVariant() {
+        String serverUrl = null;
+        if(BuildConfig.IS_DEMO) {
+            serverUrl = DEMO_SERVER_URL;
+        } else if (BuildConfig.IS_STAGING) {
+            serverUrl = STAGING_SERVER_URL;
+        } else if (BuildConfig.IS_PRODUCTION) {
+            serverUrl = PRODUCTION_SERVER_URL;
+        } else {
+            throw new IllegalStateException("Which server environment are we trying to use? Something has went wrong here.");
+        }
+
+        return serverUrl;
+    }
+
+    private String getServerTokenBasedOnBuildVariant() {
+        // All of these tokens are Shark's tokens
+        String serverToken = null;
+        if(BuildConfig.IS_DEMO) {
+            serverToken = "4|VpmKNeLkoFtZbJFTIRVpVWdclzf7LiL9sp83JuVw91ed224b";
+        } else if (BuildConfig.IS_STAGING) {
+            serverToken = "252|GI2CTemW2EX3TmQaDmCzYg1xrs3VEDslnGrfCwp245a84b22";
+        } else if (BuildConfig.IS_PRODUCTION) {
+            serverToken = "41|lAp3yiiWJH3D3ftR54seY6oMO8EEjpees7Y3oJI63b71a1d3";
+        } else {
+            throw new IllegalStateException("Which server environment are we trying to use? Something has went wrong here.");
+        }
+
+        return serverToken;
     }
 }

--- a/app/src/main/java/cloudcity/CloudCityParamsRepository.java
+++ b/app/src/main/java/cloudcity/CloudCityParamsRepository.java
@@ -173,6 +173,7 @@ public class CloudCityParamsRepository {
 
     private String getServerTokenBasedOnBuildVariant() {
         // All of these tokens are Shark's tokens
+        //TODO get rid of these tokens later on when we have actual login
         String serverToken = null;
         if(BuildConfig.IS_DEMO) {
             serverToken = "4|VpmKNeLkoFtZbJFTIRVpVWdclzf7LiL9sp83JuVw91ed224b";


### PR DESCRIPTION
This PR introduces 3 new flavors, for 'staging', 'production' and 'demo' server. It slightly changes up where the prefill data is fetched from, and will most likely also have to fix the workflow.

But then we'll end up with 3 debug and 3 release builds, each pair targetting a different server environment (and still have it changable from settings tho)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced product flavors for different server environments: Staging, Demo, and Production.
	- Enhanced server URL and token management based on the selected build variant.

- **Bug Fixes**
	- Improved error handling for unknown build variants during initialization.

- **Improvements**
	- Updated output file naming convention to reflect the current build flavor.
	- Enhanced CI process for more flexible APK file handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->