### PR TITLE
Use mac address in header instead of token

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,6 +19,8 @@
     <uses-permission
         android:name="android.permission.READ_PRECISE_PHONE_STATE"
         tools:ignore="ProtectedPermissions" />
+
+    <uses-permission android:name="android.permission.LOCAL_MAC_ADDRESS"/>
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />

--- a/app/src/main/java/cloudcity/networking/CloudCityHelpers.java
+++ b/app/src/main/java/cloudcity/networking/CloudCityHelpers.java
@@ -12,6 +12,8 @@ import retrofit2.Retrofit;
 public class CloudCityHelpers {
     public static final String TAG = CloudCityHelpers.class.getSimpleName();
 
+    private static final String X_MAC_ADDRESS_HEADER = "X-MAC-Address ";
+
     public static boolean sendData(String address, String token, NetworkDataModelRequest data) {
         Log.d(TAG, "--> sendData()\taddress=" + address + ", token=" + token + ", data=" + data);
         Retrofit retrofit = NetworkClient.getRetrofitClient(address);
@@ -24,7 +26,7 @@ public class CloudCityHelpers {
 
         try {
             Log.d(TAG, String.format(Locale.US, "sendData: Executing send data request: address %s", address));
-            response = api.sendData("Bearer " + token, data).execute();
+            response = api.sendData(X_MAC_ADDRESS_HEADER + token, data).execute();
             Log.d(TAG, String.format(Locale.US, "Received sendData response. %s", response));
 
             if (response.isSuccessful()) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -92,8 +92,8 @@
     <string name="enable_cloud_city">Cloud City log</string>
     <string name="cloud_city_url_dialog_title">Cloud City URL / IP (with protocol and port)</string>
     <string name="cloud_city_url">Cloud City instance URL / IP</string>
-    <string name="cloud_city_token_dialog_title">Set Cloud City Token</string>
-    <string name="cloud_city_token">Cloud City Token</string>
+    <string name="cloud_city_token_dialog_title">Set Cloud City MAC address</string>
+    <string name="cloud_city_token">Cloud City MAC address</string>
 
     <!-- Work Profile Management -->
 


### PR DESCRIPTION
This PR replaces the old `Bearer` authorization token with `X-MAC-Address`

The new server communication now looks like this:
```
--> POST https://staging.app.cloudcities.co/api/sensor-events
Content-Type: application/json
Content-Length: 199
Accept: application/json
Authorization: X-MAC-Address 00-B0-D0-63-C2-AA
--> END POST (199-byte body)
<-- 401 https://staging.app.cloudcities.co/api/sensor-events (234ms)
```

however it's still currently getting 401 unauthorized response.

