### PR TITLE
Do not send data to server if lat lng are zero

### DIFF
--- a/app/src/main/java/cloudcity/networking/CloudCityHelpers.java
+++ b/app/src/main/java/cloudcity/networking/CloudCityHelpers.java
@@ -50,9 +50,14 @@ public class CloudCityHelpers {
     private static boolean validateData(NetworkDataModelRequest data) {
         // Assume data is valid
         boolean isValid = true;
-        // We have valid data if lattitude and longitude are non-zero
-        for (NetworkDataModel model : data.getData()) {
-            isValid = isValid && model.hasNonZeroLatitudeAndLongitude();
+
+        if (data != null) {
+            // We have valid data if lattitude and longitude are non-zero
+            for (NetworkDataModel model : data.getData()) {
+                isValid = isValid && model.hasNonZeroLatitudeAndLongitude();
+            }
+        } else {
+            isValid = false;
         }
 
         return isValid;

--- a/app/src/main/java/cloudcity/networking/CloudCityHelpers.java
+++ b/app/src/main/java/cloudcity/networking/CloudCityHelpers.java
@@ -5,6 +5,7 @@ import android.util.Log;
 import java.io.IOException;
 import java.util.Locale;
 
+import cloudcity.networking.models.NetworkDataModel;
 import cloudcity.networking.models.NetworkDataModelRequest;
 import retrofit2.Response;
 import retrofit2.Retrofit;
@@ -23,20 +24,37 @@ public class CloudCityHelpers {
         Response<Void> response = null;
 
         try {
-            Log.d(TAG, String.format(Locale.US, "sendData: Executing send data request: address %s", address));
-            response = api.sendData("Bearer " + token, data).execute();
-            Log.d(TAG, String.format(Locale.US, "Received sendData response. %s", response));
+            // Check if data has valid Lat,Lng pair, do not send if they are (0,0)
+            boolean continueSending = validateData(data);
+            if (continueSending) {
+                Log.d(TAG, String.format(Locale.US, "sendData: Executing send data request: address %s", address));
+                response = api.sendData("Bearer " + token, data).execute();
+                Log.d(TAG, String.format(Locale.US, "Received sendData response. %s", response));
 
-            if (response.isSuccessful()) {
-                return true;
+                if (response.isSuccessful()) {
+                    return true;
+                } else {
+                    Log.d(TAG, "sendData: Send data request failed.");
+                }
+                return false;
             } else {
-                Log.d(TAG, "sendData: Send data request failed.");
+                Log.e(TAG, "sendData: data's location information was (0,0) - skipping sending!");
+                return false;
             }
-            return false;
-
         } catch (IOException e) {
             Log.e(TAG, "sendData: Failure to receive response.", e);
             return false;
         }
+    }
+
+    private static boolean validateData(NetworkDataModelRequest data) {
+        // Assume data is valid
+        boolean isValid = true;
+        // We have valid data if lattitude and longitude are non-zero
+        for (NetworkDataModel model : data.getData()) {
+            isValid = isValid && model.hasNonZeroLatitudeAndLongitude();
+        }
+
+        return isValid;
     }
 }

--- a/app/src/main/java/cloudcity/networking/models/NetworkDataModel.java
+++ b/app/src/main/java/cloudcity/networking/models/NetworkDataModel.java
@@ -20,4 +20,8 @@ public class NetworkDataModel {
     }
 
     static class NetworkDataModelValues { }
+
+    public boolean hasNonZeroLatitudeAndLongitude() {
+        return (latitude != 0f && longitude != 0f);
+    }
 }

--- a/app/src/main/java/cloudcity/networking/models/NetworkDataModel.java
+++ b/app/src/main/java/cloudcity/networking/models/NetworkDataModel.java
@@ -6,6 +6,8 @@ import com.google.gson.annotations.SerializedName;
  * Base class for our network data
  */
 public class NetworkDataModel {
+    private static final double EPSILON = 0.00001;
+
     @SerializedName("lat")
     protected final double latitude;
     @SerializedName("lon")
@@ -22,6 +24,13 @@ public class NetworkDataModel {
     static class NetworkDataModelValues { }
 
     public boolean hasNonZeroLatitudeAndLongitude() {
-        return (latitude != 0f && longitude != 0f);
+        return isNonZero(latitude) && isNonZero(longitude);
+    }
+
+    private boolean isNonZero(double value) {
+        // if we have a zero, or some very small number e.g. 0.00000000234, subtracting EPSILON
+        // from it and performing an abs() on the result will make it a number less than EPSILON
+        // since effectivelly it'd be as if we performed (EPSILON - small number)
+        return value != 0f && value != 0.0 && Math.abs(value - EPSILON) <= EPSILON;
     }
 }


### PR DESCRIPTION
Issue link: https://github.com/Cloud-City-RS/OMNTelcoMetrics/issues/34


This PR focuses on adding data validation before sending it to the server.
If any of the Request's "sensor events" contain (lat, lng) of (0,0) the data (the whole request's "sensor_events" list) will be considered invalid and will not be sent to the server.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a validation step for data before sending, ensuring valid latitude and longitude.
	- Added a method to check for non-zero latitude and longitude in the data model.

- **Bug Fixes**
	- Enhanced error handling to prevent unnecessary network calls when data is invalid.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->