### PR TITLE
Filter out cell infos whose cell types are null

### DIFF
--- a/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/QuickFragment.java
+++ b/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/QuickFragment.java
@@ -329,6 +329,7 @@ public class QuickFragment extends Fragment {
                 cellInformationList
                         .stream()
                         .filter(Objects::nonNull)
+                        .filter(cellInformation -> cellInformation.getCellType() != null)
                         .forEach(cellInformation -> addCellInformationToView(cellInformation));
             }
             if (spg.getSharedPreference(SPType.default_sp).getBoolean("show_neighbour_cells", false)) {
@@ -337,6 +338,7 @@ public class QuickFragment extends Fragment {
                     neighborCells
                             .stream()
                             .filter(Objects::nonNull)
+                            .filter(cellInformation -> cellInformation.getCellType() != null)
                             .forEach(cellInformation -> addCellInformationToView(cellInformation));
                 }
             }


### PR DESCRIPTION
The previous fix just filtered out null cell infos, but that's not enough it seems...

Similar to #19 this is just another symptomatic treatment of who knows what problem, which has happened exactly zero times to me on my Samsung phone.

Relevant stacktrace:
![image](https://github.com/user-attachments/assets/b52fd7f6-8dfd-45ec-8df0-773aaa8b3f49)
