### PR TITLE
Fix GPSMonitor initialization

### DIFF
--- a/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/MainActivity.java
+++ b/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/MainActivity.java
@@ -175,7 +175,7 @@ public class MainActivity extends AppCompatActivity implements PreferenceFragmen
         } //todo this will go very wrong on android devices without telephony api, maybe show warning and exit?
 
         // CloudCity thing
-        MainActivityExtensions.performMainActivityThing(TAG, spg, dp);
+        MainActivityExtensions.performMainActivityThing(this, spg, dp);
         // Rest of how it was before
 
         gv.set_dp(dp);


### PR DESCRIPTION
Well, all is well and great on the initial launch; the user is prompted for permissions, we react to them being granted/rejected and everything runs great.

However on subsequent app runs, we don't go trough that same code path, and we ended up not initializing some cruicial components for sending CloudCity data, namely the GPSMonitor

So, added checking whether we have teh permission and initializing it separately from the "permissions received" callback, and the code now properly initializes it if we had the permission without having to request it first.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced permission handling for background location access.
	- Improved GPS monitoring initiation based on granted permissions.

- **Bug Fixes**
	- Adjusted method calls to ensure proper context is passed for permission requests.

- **Chores**
	- Updated comments and logging for better clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->