### PR TITLE
Iperf3 test runs throttling

### DIFF
--- a/app/src/main/java/cloudcity/CloudCityConstants.java
+++ b/app/src/main/java/cloudcity/CloudCityConstants.java
@@ -23,5 +23,8 @@ public class CloudCityConstants {
     public static final int CLOUD_CITY_IPERF3_VALID_PORT_MAX = 9240;
     public static final int CLOUD_CITY_IPERF3_DEFAULT_DURATION = 30;
 
-    public static final String CLOUD_CITY_IPERF3_TEST_THROTTLING_THRESHOLD = "cloud_city_iperf3_throttling_interval";
+    // Iperf3 time-based throttling shared pref key
+    public static final String CLOUD_CITY_IPERF3_TEST_TIME_THROTTLING_THRESHOLD = "cloud_city_iperf3_throttling_interval";
+    // Iperf3 distance-based throttling shared pref key
+    public static final String CLOUD_CITY_IPERF3_TEST_DISTANCE_THROTTLING_THRESHOLD = "cloud_city_iperf3_throttling_distance";
 }

--- a/app/src/main/java/cloudcity/CloudCityConstants.java
+++ b/app/src/main/java/cloudcity/CloudCityConstants.java
@@ -22,4 +22,6 @@ public class CloudCityConstants {
     public static final int CLOUD_CITY_IPERF3_VALID_PORT_MIN = 9200;
     public static final int CLOUD_CITY_IPERF3_VALID_PORT_MAX = 9240;
     public static final int CLOUD_CITY_IPERF3_DEFAULT_DURATION = 30;
+
+    public static final String CLOUD_CITY_IPERF3_TEST_THROTTLING_THRESHOLD = "cloud_city_iperf3_throttling_interval";
 }

--- a/app/src/main/java/cloudcity/Iperf3Monitor.java
+++ b/app/src/main/java/cloudcity/Iperf3Monitor.java
@@ -534,7 +534,7 @@ public class Iperf3Monitor {
      * @param newThrottlingValueInMeters the new value to use for {@link #THROTTLING_THRESHOLD_IN_METERS}
      * @return the new (current) value of that parameter
      */
-    public float setDistanceThrottlingThreshold(int newThrottlingValueInMeters) {
+    public float setDistanceThrottlingThreshold(float newThrottlingValueInMeters) {
         Log.d(TAG, "Setting new THROTTLING_THRESHOLD_IN_METERS to "+newThrottlingValueInMeters);
         THROTTLING_THRESHOLD_IN_METERS = newThrottlingValueInMeters;
         return THROTTLING_THRESHOLD_IN_METERS;

--- a/app/src/main/java/cloudcity/MainActivityExtensions.java
+++ b/app/src/main/java/cloudcity/MainActivityExtensions.java
@@ -2,6 +2,7 @@ package cloudcity;
 
 import static cloudcity.CloudCityConstants.CLOUD_CITY_CC_LOGGING;
 import static cloudcity.CloudCityConstants.CLOUD_CITY_GENERAL_LOGGING;
+import static cloudcity.CloudCityConstants.CLOUD_CITY_IPERF3_TEST_THROTTLING_THRESHOLD;
 import static cloudcity.CloudCityConstants.CLOUD_CITY_SERVER_URL;
 import static cloudcity.CloudCityConstants.CLOUD_CITY_TOKEN;
 
@@ -50,6 +51,13 @@ public class MainActivityExtensions {
                     case CLOUD_CITY_TOKEN: {
                         String newSharedPrefValue = sharedPreferences.getString(key, "");
                         CloudCityParamsRepository.getInstance().setServerToken(newSharedPrefValue);
+                    }
+
+                    case CLOUD_CITY_IPERF3_TEST_THROTTLING_THRESHOLD: {
+                        String newSharedPrefValue = sharedPreferences.getString(key, "5");
+                        double sharedPrefValueInMinutes = Double.parseDouble(newSharedPrefValue);
+                        int sharedPrefValueInSeconds = (int)(sharedPrefValueInMinutes * 60);
+                        Iperf3Monitor.getInstance().setThrottlingThresshold(sharedPrefValueInSeconds);
                     }
                     break;
                 }

--- a/app/src/main/java/cloudcity/MainActivityExtensions.java
+++ b/app/src/main/java/cloudcity/MainActivityExtensions.java
@@ -2,7 +2,8 @@ package cloudcity;
 
 import static cloudcity.CloudCityConstants.CLOUD_CITY_CC_LOGGING;
 import static cloudcity.CloudCityConstants.CLOUD_CITY_GENERAL_LOGGING;
-import static cloudcity.CloudCityConstants.CLOUD_CITY_IPERF3_TEST_THROTTLING_THRESHOLD;
+import static cloudcity.CloudCityConstants.CLOUD_CITY_IPERF3_TEST_DISTANCE_THROTTLING_THRESHOLD;
+import static cloudcity.CloudCityConstants.CLOUD_CITY_IPERF3_TEST_TIME_THROTTLING_THRESHOLD;
 import static cloudcity.CloudCityConstants.CLOUD_CITY_SERVER_URL;
 import static cloudcity.CloudCityConstants.CLOUD_CITY_TOKEN;
 
@@ -52,12 +53,20 @@ public class MainActivityExtensions {
                         String newSharedPrefValue = sharedPreferences.getString(key, "");
                         CloudCityParamsRepository.getInstance().setServerToken(newSharedPrefValue);
                     }
+                    break;
 
-                    case CLOUD_CITY_IPERF3_TEST_THROTTLING_THRESHOLD: {
+                    case CLOUD_CITY_IPERF3_TEST_TIME_THROTTLING_THRESHOLD: {
                         String newSharedPrefValue = sharedPreferences.getString(key, "5");
                         double sharedPrefValueInMinutes = Double.parseDouble(newSharedPrefValue);
                         int sharedPrefValueInSeconds = (int)(sharedPrefValueInMinutes * 60);
-                        Iperf3Monitor.getInstance().setThrottlingThresshold(sharedPrefValueInSeconds);
+                        Iperf3Monitor.getInstance().setTimeThrottlingThreshold(sharedPrefValueInSeconds);
+                    }
+                    break;
+
+                    case CLOUD_CITY_IPERF3_TEST_DISTANCE_THROTTLING_THRESHOLD: {
+                        String newSharedPrefValue = sharedPreferences.getString(key, "0");
+                        float sharedPrefValueInMeters = Float.parseFloat(newSharedPrefValue);
+                        Iperf3Monitor.getInstance().setDistanceThrottlingThreshold(sharedPrefValueInMeters);
                     }
                     break;
                 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -95,6 +95,7 @@
     <string name="cloud_city_token_dialog_title">Set Cloud City Token</string>
     <string name="cloud_city_token">Cloud City Token</string>
     <string name="cloud_city_iperf3_test_throttling_interval">Cloud City iPerf3 test throttling (in minutes)</string>
+    <string name="cloud_city_iperf3_test_throttling_distance">Cloud City iPerf3 test throttling (in meters)</string>
 
     <!-- Work Profile Management -->
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -94,6 +94,7 @@
     <string name="cloud_city_url">Cloud City instance URL / IP</string>
     <string name="cloud_city_token_dialog_title">Set Cloud City Token</string>
     <string name="cloud_city_token">Cloud City Token</string>
+    <string name="cloud_city_iperf3_test_throttling_interval">Cloud City iPerf3 test throttling (in minutes)</string>
 
     <!-- Work Profile Management -->
 

--- a/app/src/main/res/xml/preference_logging.xml
+++ b/app/src/main/res/xml/preference_logging.xml
@@ -128,6 +128,22 @@
             app:title="@string/cloud_city_token"
             app:useSimpleSummaryProvider="true" />
 
+        <EditTextPreference
+            android:dialogTitle="@string/cloud_city_token_dialog_title"
+            app:dependency="enable_cloud_city"
+            app:iconSpaceReserved="false"
+            app:key="cloud_city_token"
+            app:title="@string/cloud_city_token"
+            app:useSimpleSummaryProvider="true" />
+
+        <EditTextPreference
+            android:dialogTitle="@string/cloud_city_iperf3_test_throttling_interval"
+            app:iconSpaceReserved="false"
+            app:key="cloud_city_iperf3_throttling_interval"
+            app:title="@string/cloud_city_iperf3_test_throttling_interval"
+            app:defaultValue="5"
+            app:useSimpleSummaryProvider="true" />
+
     </PreferenceCategory>
 
     <PreferenceCategory

--- a/app/src/main/res/xml/preference_logging.xml
+++ b/app/src/main/res/xml/preference_logging.xml
@@ -129,14 +129,6 @@
             app:useSimpleSummaryProvider="true" />
 
         <EditTextPreference
-            android:dialogTitle="@string/cloud_city_token_dialog_title"
-            app:dependency="enable_cloud_city"
-            app:iconSpaceReserved="false"
-            app:key="cloud_city_token"
-            app:title="@string/cloud_city_token"
-            app:useSimpleSummaryProvider="true" />
-
-        <EditTextPreference
             android:dialogTitle="@string/cloud_city_iperf3_test_throttling_interval"
             app:iconSpaceReserved="false"
             app:key="cloud_city_iperf3_throttling_interval"

--- a/app/src/main/res/xml/preference_logging.xml
+++ b/app/src/main/res/xml/preference_logging.xml
@@ -144,6 +144,14 @@
             app:defaultValue="5"
             app:useSimpleSummaryProvider="true" />
 
+        <EditTextPreference
+            android:dialogTitle="@string/cloud_city_iperf3_test_throttling_distance"
+            app:iconSpaceReserved="false"
+            app:key="cloud_city_iperf3_throttling_distance"
+            app:title="@string/cloud_city_iperf3_test_throttling_distance"
+            app:defaultValue="0"
+            app:useSimpleSummaryProvider="true" />
+
     </PreferenceCategory>
 
     <PreferenceCategory


### PR DESCRIPTION
Issue link:
https://github.com/Cloud-City-RS/OMNTelcoMetrics/issues/35


Since the iperf3 tests eat away too much data, we need to throttle them;
but since it's not the API requests that are eating data but the iPerf3 tests
themselves - we need to throttle how often do we run test.

This PR introduces the time-based throttling (constraint) which defaults to 5 minutes but is configurable from the Settings/Logging screen where all the other CloudCity settings are.

Still to be done is the distance-based throttling which checks whether the distance between the last two locations is over some threshold and, if it is, ignores the time-based throttling and runs the test.

UPDATE: distance-based check was implemented in 5de2f4e f273394 b3c7499

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced a new throttling mechanism for iPerf3 tests, allowing users to set both time and distance intervals between tests.
	- Added support for user-defined throttling intervals and distances through app preferences.

- **Bug Fixes**
	- Enhanced error handling to prevent potential null pointer exceptions in cell information retrieval.

- **Documentation**
	- Added new user-facing strings to describe the throttling interval and distance for iPerf3 tests.

- **Chores**
	- Minor adjustments to preference logging XML for improved structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->