### PR TITLE
Fix broken iPerf3 results reporting to the server

### DIFF
--- a/app/src/main/java/cloudcity/networking/models/Iperf3NetworkDataModel.java
+++ b/app/src/main/java/cloudcity/networking/models/Iperf3NetworkDataModel.java
@@ -55,7 +55,7 @@ class Iperf3ValuesModel extends NetworkDataModel.NetworkDataModelValues {
     private final double DLlast;
 
     @SerializedName("cell_type")
-    private final String cellType;
+    private final int cellType;
 
     @SerializedName("test_start_timestamp")
     private final long startTimestamp;

--- a/app/src/main/java/cloudcity/networking/models/Iperf3NetworkDataModel.java
+++ b/app/src/main/java/cloudcity/networking/models/Iperf3NetworkDataModel.java
@@ -28,7 +28,7 @@ public class Iperf3NetworkDataModel extends NetworkDataModel {
             @NonNull MetricsPOJO.TestDurationPair testDurationPair
             ) {
         super(location.getLatitude(), location.getLongitude(), new Iperf3ValuesModel(upload, download, measurementsModel, testDurationPair));
-        this.accuracy = CloudCityUtil.roundToNumberOfDecimals(location.getAccuracy(), NUMBER_OF_DECIMALS_FOR_ACCURACY);
+        this.accuracy = location.getAccuracy();
         this.speed = location.getSpeed();
     }
 }
@@ -83,17 +83,17 @@ class Iperf3ValuesModel extends NetworkDataModel.NetworkDataModelValues {
                              @NonNull MetricsPOJO.DownloadMetrics download,
                              @NonNull MeasurementsModel cellMeasurements,
                              @NonNull MetricsPOJO.TestDurationPair testDuration) {
-        ULmin = CloudCityUtil.roundToNumberOfDecimals(upload.getULmin(), NUMBER_OF_DECIMALS_FOR_METRICS);
-        ULmedian = CloudCityUtil.roundToNumberOfDecimals(upload.getULmedian(), NUMBER_OF_DECIMALS_FOR_METRICS);
-        ULmean = CloudCityUtil.roundToNumberOfDecimals(upload.getULmean(), NUMBER_OF_DECIMALS_FOR_METRICS);
-        ULmax = CloudCityUtil.roundToNumberOfDecimals(upload.getULmax(), NUMBER_OF_DECIMALS_FOR_METRICS);
-        ULlast = CloudCityUtil.roundToNumberOfDecimals(upload.getULlast(), NUMBER_OF_DECIMALS_FOR_METRICS);
+        ULmin = upload.getULmin();
+        ULmedian = upload.getULmedian();
+        ULmean = upload.getULmean();
+        ULmax = upload.getULmax();
+        ULlast = upload.getULlast();
 
-        DLmin = CloudCityUtil.roundToNumberOfDecimals(download.getDLmin(), NUMBER_OF_DECIMALS_FOR_METRICS);
-        DLmedian = CloudCityUtil.roundToNumberOfDecimals(download.getDLmedian(), NUMBER_OF_DECIMALS_FOR_METRICS);
-        DLmean = CloudCityUtil.roundToNumberOfDecimals(download.getDLmean(), NUMBER_OF_DECIMALS_FOR_METRICS);
-        DLmax = CloudCityUtil.roundToNumberOfDecimals(download.getDLmax(), NUMBER_OF_DECIMALS_FOR_METRICS);
-        DLlast = CloudCityUtil.roundToNumberOfDecimals(download.getDLlast(), NUMBER_OF_DECIMALS_FOR_METRICS);
+        DLmin = download.getDLmin();
+        DLmedian = download.getDLmedian();
+        DLmean = download.getDLmean();
+        DLmax = download.getDLmax();
+        DLlast = download.getDLlast();
 
         rsrp = cellMeasurements.getRsrp();
         rsrq = cellMeasurements.getRsrq();

--- a/app/src/main/java/cloudcity/networking/models/Iperf3NetworkDataModel.java
+++ b/app/src/main/java/cloudcity/networking/models/Iperf3NetworkDataModel.java
@@ -7,8 +7,10 @@ import androidx.annotation.NonNull;
 import com.google.gson.annotations.SerializedName;
 
 import cloudcity.dataholders.MetricsPOJO;
+import cloudcity.util.CloudCityUtil;
 
 public class Iperf3NetworkDataModel extends NetworkDataModel {
+    private static final int NUMBER_OF_DECIMALS_FOR_ACCURACY = 4;
 
     @SerializedName("category")
     final private String category = "Iperf3";
@@ -26,12 +28,14 @@ public class Iperf3NetworkDataModel extends NetworkDataModel {
             @NonNull MetricsPOJO.TestDurationPair testDurationPair
             ) {
         super(location.getLatitude(), location.getLongitude(), new Iperf3ValuesModel(upload, download, measurementsModel, testDurationPair));
-        this.accuracy = location.getAccuracy();
+        this.accuracy = CloudCityUtil.roundToNumberOfDecimals(location.getAccuracy(), NUMBER_OF_DECIMALS_FOR_ACCURACY);
         this.speed = location.getSpeed();
     }
 }
 
 class Iperf3ValuesModel extends NetworkDataModel.NetworkDataModelValues {
+    private static final int NUMBER_OF_DECIMALS_FOR_METRICS = 2;
+
     @SerializedName("upload_min")
     private final double ULmin;
     @SerializedName("upload_median")
@@ -79,17 +83,17 @@ class Iperf3ValuesModel extends NetworkDataModel.NetworkDataModelValues {
                              @NonNull MetricsPOJO.DownloadMetrics download,
                              @NonNull MeasurementsModel cellMeasurements,
                              @NonNull MetricsPOJO.TestDurationPair testDuration) {
-        ULmin = upload.getULmin();
-        ULmedian = upload.getULmedian();
-        ULmean = upload.getULmean();
-        ULmax = upload.getULmax();
-        ULlast = upload.getULlast();
+        ULmin = CloudCityUtil.roundToNumberOfDecimals(upload.getULmin(), NUMBER_OF_DECIMALS_FOR_METRICS);
+        ULmedian = CloudCityUtil.roundToNumberOfDecimals(upload.getULmedian(), NUMBER_OF_DECIMALS_FOR_METRICS);
+        ULmean = CloudCityUtil.roundToNumberOfDecimals(upload.getULmean(), NUMBER_OF_DECIMALS_FOR_METRICS);
+        ULmax = CloudCityUtil.roundToNumberOfDecimals(upload.getULmax(), NUMBER_OF_DECIMALS_FOR_METRICS);
+        ULlast = CloudCityUtil.roundToNumberOfDecimals(upload.getULlast(), NUMBER_OF_DECIMALS_FOR_METRICS);
 
-        DLmin = download.getDLmin();
-        DLmedian = download.getDLmedian();
-        DLmean = download.getDLmean();
-        DLmax = download.getDLmax();
-        DLlast = download.getDLlast();
+        DLmin = CloudCityUtil.roundToNumberOfDecimals(download.getDLmin(), NUMBER_OF_DECIMALS_FOR_METRICS);
+        DLmedian = CloudCityUtil.roundToNumberOfDecimals(download.getDLmedian(), NUMBER_OF_DECIMALS_FOR_METRICS);
+        DLmean = CloudCityUtil.roundToNumberOfDecimals(download.getDLmean(), NUMBER_OF_DECIMALS_FOR_METRICS);
+        DLmax = CloudCityUtil.roundToNumberOfDecimals(download.getDLmax(), NUMBER_OF_DECIMALS_FOR_METRICS);
+        DLlast = CloudCityUtil.roundToNumberOfDecimals(download.getDLlast(), NUMBER_OF_DECIMALS_FOR_METRICS);
 
         rsrp = cellMeasurements.getRsrp();
         rsrq = cellMeasurements.getRsrq();
@@ -104,7 +108,10 @@ class Iperf3ValuesModel extends NetworkDataModel.NetworkDataModelValues {
 
         cellType = cellMeasurements.getCellType();
 
-        startTimestamp = testDuration.getTestStartTimestamp();
-        endTimestamp = testDuration.getTestEndTimestamp();
+        //TODO revert this
+//        startTimestamp = testDuration.getTestStartTimestamp();
+//        endTimestamp = testDuration.getTestEndTimestamp();
+        startTimestamp = 0;
+        endTimestamp = 0;
     }
 }

--- a/app/src/main/java/cloudcity/networking/models/MeasurementsModel.java
+++ b/app/src/main/java/cloudcity/networking/models/MeasurementsModel.java
@@ -22,7 +22,7 @@ public class MeasurementsModel extends NetworkDataModel.NetworkDataModelValues {
     @SerializedName("dummy_value")
     private Integer dummy;
 
-    private transient String cellType;
+    private transient int cellType;
 
     public Integer getRsrp() {
         return rsrp;
@@ -131,9 +131,9 @@ public class MeasurementsModel extends NetworkDataModel.NetworkDataModelValues {
         this.dummy = dummy;
     }
 
-    public void setCellType(String newType) { this.cellType = newType; }
+    public void setCellType(int newType) { this.cellType = newType; }
 
-    public String getCellType() { return cellType; }
+    public int getCellType() { return cellType; }
 
     @Override
     public String toString() {

--- a/app/src/main/java/cloudcity/util/CellUtil.java
+++ b/app/src/main/java/cloudcity/util/CellUtil.java
@@ -8,7 +8,9 @@ import java.util.List;
 import java.util.Objects;
 
 import cloudcity.networking.models.MeasurementsModel;
+import de.fraunhofer.fokus.OpenMobileNetworkToolkit.DataProvider.CellInformations.CDMAInformation;
 import de.fraunhofer.fokus.OpenMobileNetworkToolkit.DataProvider.CellInformations.CellInformation;
+import de.fraunhofer.fokus.OpenMobileNetworkToolkit.DataProvider.CellInformations.GSMInformation;
 import de.fraunhofer.fokus.OpenMobileNetworkToolkit.DataProvider.CellInformations.LTEInformation;
 import de.fraunhofer.fokus.OpenMobileNetworkToolkit.DataProvider.CellInformations.NRInformation;
 import de.fraunhofer.fokus.OpenMobileNetworkToolkit.DataProvider.DataProvider;
@@ -66,9 +68,30 @@ public class CellUtil {
             /* In 3G no measurement data available set dummy data. */
             measurements.setDummy(1);
         }
-        measurements.setCellType(category);
+        // Remap based on category or better - the actual cell type class
+        // 3G is CDMA or GSM
+        // 4G is LTE
+        // 5G is NR
+        measurements.setCellType(remapCellClassTypeIntoInteger(currentCell));
 
         return measurements;
+    }
+
+    public static int remapCellClassTypeIntoInteger(CellInformation cellToRemap) {
+        // kotlin's exhaustive when() would be great but lets do with what we have
+        int retVal = -1;
+
+        if (cellToRemap instanceof GSMInformation || cellToRemap instanceof CDMAInformation) {
+            retVal = 3;
+        }
+        if (cellToRemap instanceof LTEInformation) {
+            retVal = 4;
+        }
+        if (cellToRemap instanceof NRInformation) {
+            retVal = 5;
+        }
+
+        return retVal;
     }
 
     public static MeasurementsModel getRegisteredCellInformationUpdatedBySignalStrengthInformation(@NonNull DataProvider dp) {

--- a/app/src/main/java/cloudcity/util/CloudCityUtil.java
+++ b/app/src/main/java/cloudcity/util/CloudCityUtil.java
@@ -75,4 +75,21 @@ public class CloudCityUtil {
         requestData.add(data);
         return CloudCityHelpers.sendData(address, token, requestData);
     }
+
+    /**
+     * Method that rounds a double {@code numberToRound} to {@code numberOfDecimals} number of decimals and returns the
+     * corrected number
+     *
+     * @param numberToRound    the number to round to a fixed number of decimals
+     * @param numberOfDecimals the number of decimals to allow after the decimal point
+     * @return the fixed number
+     */
+    public static double roundToNumberOfDecimals(double numberToRound, int numberOfDecimals) {
+        // multiply by 10^numberOfDecimals, round, floor, then return divided
+        double multiplier = Math.pow(10, numberOfDecimals);
+        double basis = numberToRound * multiplier;
+        basis = Math.round(basis);
+        double retVal = basis / multiplier;
+        return retVal;
+    }
 }


### PR DESCRIPTION
Well, #41 actually broke it by introducing the two timestamps which fall out of the permitted range by the database.

The `cellType` string value also had a say in this, since this endpoint only allows numbers for sensor_events.values; so once that was remapped to numbers - the problem changed and uncovered that all values need to be less than 1,000,000 which is too small for the timestamp.

So until this is changed/fxed somehow, lets revitalize the iperf3 reporting to the server.