### PR TITLE
Fix RSSNR reading

### DIFF
--- a/app/src/main/java/cloudcity/LoggingServiceExtensions.java
+++ b/app/src/main/java/cloudcity/LoggingServiceExtensions.java
@@ -169,11 +169,11 @@ public class LoggingServiceExtensions {
 
         // Lets initialize our MeasurementModel for sending from the registered cell model, then overwrite it's values
         // with what we found in the SignalInformation
-        MeasurementsModel modelForSending =
-                CellUtil.updateMeasurementModelByCell(
-                        CellUtil.getMeasurementsModel(category, currentCell),
-                        currentSignal
-                );
+        MeasurementsModel modelForSending = CellUtil.getMeasurementsModel(currentCell, currentSignal, CellUtil.CellInfoPrecedence.SIGNAL_INFO);
+//                CellUtil.updateMeasurementModelByCell(
+//                        CellUtil.getMeasurementsModel(category, currentCell),
+//                        currentSignal
+//                );
 
         Location location = GPSMonitor.getLastLocation();
 

--- a/app/src/main/java/cloudcity/LoggingServiceExtensions.java
+++ b/app/src/main/java/cloudcity/LoggingServiceExtensions.java
@@ -172,7 +172,7 @@ public class LoggingServiceExtensions {
         MeasurementsModel modelForSending =
                 CellUtil.updateMeasurementModelByCell(
                         CellUtil.getMeasurementsModel(category, currentCell),
-                        currentCell
+                        currentSignal
                 );
 
         Location location = GPSMonitor.getLastLocation();

--- a/app/src/main/java/cloudcity/LoggingServiceExtensions.java
+++ b/app/src/main/java/cloudcity/LoggingServiceExtensions.java
@@ -170,10 +170,6 @@ public class LoggingServiceExtensions {
         // Lets initialize our MeasurementModel for sending from the registered cell model, then overwrite it's values
         // with what we found in the SignalInformation
         MeasurementsModel modelForSending = CellUtil.getMeasurementsModel(currentCell, currentSignal, CellUtil.CellInfoPrecedence.SIGNAL_INFO);
-//                CellUtil.updateMeasurementModelByCell(
-//                        CellUtil.getMeasurementsModel(category, currentCell),
-//                        currentSignal
-//                );
 
         Location location = GPSMonitor.getLastLocation();
 

--- a/app/src/main/java/cloudcity/LoggingServiceExtensions.java
+++ b/app/src/main/java/cloudcity/LoggingServiceExtensions.java
@@ -39,7 +39,7 @@ public class LoggingServiceExtensions {
 
     private static int interval;
 
-    private static DataProvider dp;
+    private static volatile DataProvider dp;
 
     private static HandlerThread handlerThread;
 

--- a/app/src/main/java/cloudcity/util/CellUtil.java
+++ b/app/src/main/java/cloudcity/util/CellUtil.java
@@ -147,6 +147,7 @@ public class CellUtil {
             // Assume signalStrength is the same
             NRInformation nrSignal = (NRInformation) signalStrength;
             //TODO get rid of this workaround
+            //FIXME get rid of this workaround
             if (nrSignal == null) nrSignal = nrCell;
 
             Integer validCsirsrp = getNonNullAndNonInvalidMember(nrCell.getCsirsrp(), nrSignal.getCsirsrp(), precedence);
@@ -167,6 +168,7 @@ public class CellUtil {
             // Likewise, assume signal strength is the same
             LTEInformation lteSignal = (LTEInformation) signalStrength;
             //TODO get rid of this workaround
+            //FIXME get rid of this workaround
             if (lteSignal == null) lteSignal = lteCell;
 
             Integer validRsrp = getNonNullAndNonInvalidMember(lteCell.getRsrp(), lteSignal.getRsrp(), precedence);

--- a/app/src/main/java/cloudcity/util/CellUtil.java
+++ b/app/src/main/java/cloudcity/util/CellUtil.java
@@ -117,6 +117,9 @@ public class CellUtil {
 
     /**
      * Extract various measurement data from the currently registered {@link CellInformation} as returned by {@link DataProvider}
+     * <p>
+     * <b>NOTE: in case 'null' is received for {@code signalStrength} then it will resort to using the {@code currentCell} instead of it</b>
+     *
      * @param currentCell the currently-registered cell to get information from
      * @param signalStrength the signal strength to get information from
      * @param precedence which cell info should take precedence
@@ -133,19 +136,25 @@ public class CellUtil {
         // If both of them are null, well then, take the null that takes precedence since it changes nothing
         //
         // We are in a bad situation if currentCell and signalStrength can end up being of different types.
+        Log.v(TAG, "--> getMeasurementsModel()\tcurrentCell: "+currentCell+", signalStrength: "+signalStrength+", precedence: "+precedence);
+        if (signalStrength == null) {
+            Log.e(TAG, "signalStrength was NULL !!! will use currentCell for both values to retain functionality.");
+        }
 
         // New safety
         if (currentCell instanceof NRInformation) {
             NRInformation nrCell = (NRInformation) currentCell;
             // Assume signalStrength is the same
             NRInformation nrSignal = (NRInformation) signalStrength;
+            //TODO get rid of this workaround
+            if (nrSignal == null) nrSignal = nrCell;
 
-            Integer validCsirsrp = getNonNullAndNonInvalidMember(nrCell.getCsirsrp(), nrSignal.getCsirsrp(), CellInfoPrecedence.SIGNAL_INFO);
-            Integer validCsirsrq = getNonNullAndNonInvalidMember(nrCell.getCsirsrq(), nrSignal.getCsirsrq(), CellInfoPrecedence.SIGNAL_INFO);
-            Integer validCsisinr = getNonNullAndNonInvalidMember(nrCell.getCsisinr(), nrSignal.getCsisinr(), CellInfoPrecedence.SIGNAL_INFO);
-            Integer validSsrsrp = getNonNullAndNonInvalidMember(nrCell.getSsrsrp(), nrSignal.getSsrsrp(), CellInfoPrecedence.SIGNAL_INFO);
-            Integer validSsrsrq = getNonNullAndNonInvalidMember(nrCell.getSsrsrq(), nrSignal.getSsrsrq(), CellInfoPrecedence.SIGNAL_INFO);
-            Integer validSssinr = getNonNullAndNonInvalidMember(nrCell.getSssinr(), nrSignal.getSssinr(), CellInfoPrecedence.SIGNAL_INFO);
+            Integer validCsirsrp = getNonNullAndNonInvalidMember(nrCell.getCsirsrp(), nrSignal.getCsirsrp(), precedence);
+            Integer validCsirsrq = getNonNullAndNonInvalidMember(nrCell.getCsirsrq(), nrSignal.getCsirsrq(), precedence);
+            Integer validCsisinr = getNonNullAndNonInvalidMember(nrCell.getCsisinr(), nrSignal.getCsisinr(), precedence);
+            Integer validSsrsrp = getNonNullAndNonInvalidMember(nrCell.getSsrsrp(), nrSignal.getSsrsrp(), precedence);
+            Integer validSsrsrq = getNonNullAndNonInvalidMember(nrCell.getSsrsrq(), nrSignal.getSsrsrq(), precedence);
+            Integer validSssinr = getNonNullAndNonInvalidMember(nrCell.getSssinr(), nrSignal.getSssinr(), precedence);
 
             measurements.setCsirsrp(validCsirsrp);
             measurements.setCsirsrq(validCsirsrq);
@@ -157,10 +166,12 @@ public class CellUtil {
             LTEInformation lteCell = (LTEInformation) currentCell;
             // Likewise, assume signal strength is the same
             LTEInformation lteSignal = (LTEInformation) signalStrength;
+            //TODO get rid of this workaround
+            if (lteSignal == null) lteSignal = lteCell;
 
-            Integer validRsrp = getNonNullAndNonInvalidMember(lteCell.getRsrp(), lteSignal.getRsrp(), CellInfoPrecedence.SIGNAL_INFO);
-            Integer validRsrq = getNonNullAndNonInvalidMember(lteCell.getRsrq(), lteSignal.getRsrq(), CellInfoPrecedence.SIGNAL_INFO);
-            Integer validRssnr = getNonNullAndNonInvalidMember(lteCell.getRssnr(), lteSignal.getRssnr(), CellInfoPrecedence.SIGNAL_INFO);
+            Integer validRsrp = getNonNullAndNonInvalidMember(lteCell.getRsrp(), lteSignal.getRsrp(), precedence);
+            Integer validRsrq = getNonNullAndNonInvalidMember(lteCell.getRsrq(), lteSignal.getRsrq(), precedence);
+            Integer validRssnr = getNonNullAndNonInvalidMember(lteCell.getRssnr(), lteSignal.getRssnr(), precedence);
 
             measurements.setRsrp(validRsrp);
             measurements.setRsrq(validRsrq);
@@ -175,6 +186,7 @@ public class CellUtil {
         // 5G is NR
         measurements.setCellType(remapCellClassTypeIntoInteger(currentCell));
 
+        Log.v(TAG, "<-- getMeasurementsModel()\tmeasurements: " + measurements);
         return measurements;
     }
 

--- a/app/src/main/java/cloudcity/util/CellUtil.java
+++ b/app/src/main/java/cloudcity/util/CellUtil.java
@@ -147,12 +147,6 @@ public class CellUtil {
             Integer validSsrsrq = getNonNullAndNonInvalidMember(nrCell.getSsrsrq(), nrSignal.getSsrsrq(), CellInfoPrecedence.SIGNAL_INFO);
             Integer validSssinr = getNonNullAndNonInvalidMember(nrCell.getSssinr(), nrSignal.getSssinr(), CellInfoPrecedence.SIGNAL_INFO);
 
-//            measurements.setCsirsrp(nrCell.getCsirsrp());
-//            measurements.setCsirsrq(nrCell.getCsirsrq());
-//            measurements.setCsisinr(nrCell.getCsisinr());
-//            measurements.setSsrsrp(nrCell.getSsrsrp());
-//            measurements.setSsrsrq(nrCell.getSsrsrq());
-//            measurements.setSssinr(nrCell.getSssinr());
             measurements.setCsirsrp(validCsirsrp);
             measurements.setCsirsrq(validCsirsrq);
             measurements.setCsisinr(validCsisinr);
@@ -167,10 +161,6 @@ public class CellUtil {
             Integer validRsrp = getNonNullAndNonInvalidMember(lteCell.getRsrp(), lteSignal.getRsrp(), CellInfoPrecedence.SIGNAL_INFO);
             Integer validRsrq = getNonNullAndNonInvalidMember(lteCell.getRsrq(), lteSignal.getRsrq(), CellInfoPrecedence.SIGNAL_INFO);
             Integer validRssnr = getNonNullAndNonInvalidMember(lteCell.getRssnr(), lteSignal.getRssnr(), CellInfoPrecedence.SIGNAL_INFO);
-
-//            measurements.setRsrp(lteCell.getRsrp());
-//            measurements.setRsrq(lteCell.getRsrq());
-//            measurements.setRssnr(lteCell.getRssnr());
 
             measurements.setRsrp(validRsrp);
             measurements.setRsrq(validRsrq);


### PR DESCRIPTION
tl;dr there were three different ways we were doing the whole "grab registered cell, initialize the measurements model and update with signal strength" except that in one of those places we weren't updating with signal strength but with registered cell again... 

So a new method was made to allow less of these mistakes to happen.
Now we either have to get the measurementsModel (to be sent) from both the currentCell and the signalStrength **or** by using the method that does all of this by just giving it an instance of the OMNT `DataProvider`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a method to retrieve registered cell and signal strength information, enhancing measurement model initialization.
	- Added a new enum to manage signal information precedence.

- **Bug Fixes**
	- Improved error handling for null data providers, ensuring robust measurement model creation.

- **Refactor**
	- Updated the logic for constructing the measurement model to prioritize valid values based on signal strength and cell information.
	- Enhanced control flow with clearer precedence handling and improved error management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->