### PR TITLE
Change iperf3 test to last 10secs

### DIFF
--- a/app/src/main/java/cloudcity/CloudCityConstants.java
+++ b/app/src/main/java/cloudcity/CloudCityConstants.java
@@ -41,6 +41,16 @@ public class CloudCityConstants {
      */
     public static final int CLOUD_CITY_IPERF3_TEST_DURATION_IN_SECONDS = 10;
 
+    /**
+     * The threshold value we need to be under to start the iPerf3 test
+     * Since 1m/s = 3.6km/h, and we need to run tests as long as we're under 5km/h, we're looking at something ~1.8m/s
+     */
+    public static final float CLOUD_CITY_IPERF3_TEST_SPEED_THRESHOLD_VALUE = 1.8f;
+    /**
+     * How long do we need to be under threshold to fire a callback that starts the automated iPerf3 test
+     */
+    public static final int CLOUD_CITY_IPERF3_TEST_SPEED_THRESHOLD_DURATION_IN_MILLIS = 5000;
+
     // Iperf3 time-based throttling shared pref key
     public static final String CLOUD_CITY_IPERF3_TEST_TIME_THROTTLING_THRESHOLD = "cloud_city_iperf3_throttling_interval";
     // Iperf3 distance-based throttling shared pref key

--- a/app/src/main/java/cloudcity/CloudCityConstants.java
+++ b/app/src/main/java/cloudcity/CloudCityConstants.java
@@ -44,10 +44,14 @@ public class CloudCityConstants {
     /**
      * The threshold value we need to be under to start the iPerf3 test
      * Since 1m/s = 3.6km/h, and we need to run tests as long as we're under 5km/h, we're looking at something ~1.8m/s
+     *
+     * Used only for CloudCity automated tests
      */
     public static final float CLOUD_CITY_IPERF3_TEST_SPEED_THRESHOLD_VALUE = 1.8f;
     /**
      * How long do we need to be under threshold to fire a callback that starts the automated iPerf3 test
+     *
+     * Used only for CloudCity automated tests
      */
     public static final int CLOUD_CITY_IPERF3_TEST_SPEED_THRESHOLD_DURATION_IN_MILLIS = 5000;
 

--- a/app/src/main/java/cloudcity/CloudCityConstants.java
+++ b/app/src/main/java/cloudcity/CloudCityConstants.java
@@ -43,11 +43,11 @@ public class CloudCityConstants {
 
     /**
      * The threshold value we need to be under to start the iPerf3 test
-     * Since 1m/s = 3.6km/h, and we need to run tests as long as we're under 5km/h, we're looking at something ~1.8m/s
+     * Since 1m/s = 3.6km/h, and we need to run tests as long as we're under 5km/h, we're looking at something ~1.3888m/s
      *
      * Used only for CloudCity automated tests
      */
-    public static final float CLOUD_CITY_IPERF3_TEST_SPEED_THRESHOLD_VALUE = 1.8f;
+    public static final float CLOUD_CITY_IPERF3_TEST_SPEED_THRESHOLD_VALUE = 1.4f;
     /**
      * How long do we need to be under threshold to fire a callback that starts the automated iPerf3 test
      *

--- a/app/src/main/java/cloudcity/CloudCityConstants.java
+++ b/app/src/main/java/cloudcity/CloudCityConstants.java
@@ -18,10 +18,28 @@ public class CloudCityConstants {
 
 
     // Iperf3Fragment constants
+    /**
+     * iPerf3 server to use for iperf3 tests; used for Settings screen prefilling as well as CloudCity automated tests
+     */
     public static final String CLOUD_CITY_IPERF3_SERVER = "demo.app.cloudcities.co";
+    /**
+     * iPerf3 server port range to use for iperf3 tests, this one is the smaller of the two ports in the range;
+     * used for Settings screen prefilling as well as CloudCity automated tests
+     */
     public static final int CLOUD_CITY_IPERF3_VALID_PORT_MIN = 9200;
+    /**
+     * iPerf3 server port range to use for iperf3 tests, this one is the larger of the two ports in the range;
+     * used for Settings screen prefilling as well as CloudCity automated tests
+     */
     public static final int CLOUD_CITY_IPERF3_VALID_PORT_MAX = 9240;
+    /**
+     * iPerf3 test duration; used for Settings screen prefilling
+     */
     public static final int CLOUD_CITY_IPERF3_DEFAULT_DURATION = 30;
+    /**
+     * iPerf3 automated iperf3 test duration; used only for CloudCity automated tests
+     */
+    public static final int CLOUD_CITY_IPERF3_TEST_DURATION_IN_SECONDS = 10;
 
     // Iperf3 time-based throttling shared pref key
     public static final String CLOUD_CITY_IPERF3_TEST_TIME_THROTTLING_THRESHOLD = "cloud_city_iperf3_throttling_interval";

--- a/app/src/main/java/cloudcity/GPSMonitor.java
+++ b/app/src/main/java/cloudcity/GPSMonitor.java
@@ -26,7 +26,7 @@ import cloudcity.dataholders.TimerWrapper;
 
 /**
  * Class for monitoring GPS location and speed via {@link LocationManager}, monitoring if the speed
- * is under threshold {@link #THRESHOLD_VALUE} for minimum threshold millis {@link #THRESHOLD_DURATION},
+ * is under threshold {@link CloudCityConstants#CLOUD_CITY_IPERF3_TEST_SPEED_THRESHOLD_VALUE} for minimum threshold millis {@link CloudCityConstants#CLOUD_CITY_IPERF3_TEST_SPEED_THRESHOLD_DURATION_IN_MILLIS},
  * firing callbacks via {@link ValueMonitorCallback} when that condition has been met.
  */
 public class GPSMonitor {
@@ -34,14 +34,6 @@ public class GPSMonitor {
     private static final long GPS_POLLING_SPEED_IN_MS = 1000L;
     private static final long GPS_POLLING_MIN_DIST_IN_M = 0L;
 
-    /**
-     * The threshold value we need to be under to start the Iperf3 test
-     */
-    private static final int THRESHOLD_VALUE = 5;
-    /**
-     * How long do we need to be under threshold to fire a callback
-     */
-    private static final int THRESHOLD_DURATION = 5000;
     /**
      * How often to poll the value, in milliseconds<p>
      * Try to keep it faster then {@link #GPS_POLLING_SPEED_IN_MS}
@@ -176,7 +168,7 @@ public class GPSMonitor {
 
     /**
      * Start monitoring for GPS location changes, and turn on the internal {@link ValueMonitor}
-     * and assign it a {@link ValueMonitorCallback} to call {@link Iperf3Monitor#startDefault15secTest()}
+     * and assign it a {@link ValueMonitorCallback} to call {@link Iperf3Monitor#startDefaultAutomatedTest(Location)}
      */
     public void startMonitoring() {
         Log.d(TAG, "--> startMonitoring()");
@@ -196,7 +188,7 @@ public class GPSMonitor {
 
         valueMonitor = new ValueMonitor();
         valueMonitor.setCallback(() -> {
-            Iperf3Monitor.getInstance().startDefault15secTest(lastLocation);
+            Iperf3Monitor.getInstance().startDefaultAutomatedTest(lastLocation);
         });
         valueMonitor.startMonitoring();
 
@@ -271,8 +263,8 @@ public class GPSMonitor {
 
         private final TimerWrapper timer;
         /**
-         * Callback that will be invoked when the monitored value has been under {@link #THRESHOLD_VALUE}
-         * for at least {@link #THRESHOLD_DURATION} millis
+         * Callback that will be invoked when the monitored value has been under {@link CloudCityConstants#CLOUD_CITY_IPERF3_TEST_SPEED_THRESHOLD_VALUE}
+         * for at least {@link CloudCityConstants#CLOUD_CITY_IPERF3_TEST_SPEED_THRESHOLD_DURATION_IN_MILLIS} millis
          */
         private @Nullable ValueMonitorCallback callback;
 
@@ -314,12 +306,12 @@ public class GPSMonitor {
          * Logic to monitor the value and track the time under threshold
          */
         private void monitorValue() {
-            if (lastSpeed < THRESHOLD_VALUE) {
+            if (lastSpeed < CloudCityConstants.CLOUD_CITY_IPERF3_TEST_SPEED_THRESHOLD_VALUE) {
                 // If value is under threshold, increment the time under threshold
                 timeUnderThreshold.addAndGet(VALUE_MONITOR_INTERVAL);
 
                 // Check if the time under threshold exceeds 5 seconds
-                if (timeUnderThreshold.get() >= THRESHOLD_DURATION) {
+                if (timeUnderThreshold.get() >= CloudCityConstants.CLOUD_CITY_IPERF3_TEST_SPEED_THRESHOLD_DURATION_IN_MILLIS) {
                     Log.d(TAG, "value has been under threshold for " + timeUnderThreshold + "ms, firing callback");
                     // Trigger the callback if the condition is met
                     if (callback != null) {
@@ -341,8 +333,8 @@ public class GPSMonitor {
      */
     interface ValueMonitorCallback {
         /**
-         * Callback to be invoked when the speed has been under {@link #THRESHOLD_VALUE}
-         * for at least {@link #THRESHOLD_DURATION} millis
+         * Callback to be invoked when the speed has been under {@link CloudCityConstants#CLOUD_CITY_IPERF3_TEST_SPEED_THRESHOLD_VALUE}
+         * for at least {@link CloudCityConstants#CLOUD_CITY_IPERF3_TEST_SPEED_THRESHOLD_DURATION_IN_MILLIS} millis
          */
         void onUnderThresholdValueForAtLeastThresholdDuration();
     }

--- a/app/src/main/java/cloudcity/Iperf3Monitor.java
+++ b/app/src/main/java/cloudcity/Iperf3Monitor.java
@@ -62,7 +62,7 @@ import de.fraunhofer.fokus.OpenMobileNetworkToolkit.R;
  * work together.
  *
  * @see #startListeningForIperf3Updates(Iperf3MonitorCompletionListener)
- * @see #startDefault15secTest(Location)
+ * @see #startDefaultAutomatedTest(Location)
  */
 public class Iperf3Monitor {
     /**
@@ -540,7 +540,11 @@ public class Iperf3Monitor {
         return THROTTLING_THRESHOLD_IN_METERS;
     }
 
-    public void startDefault15secTest(Location testRunLocation) {
+    /**
+     * Runs the default CloudCity automated iperf3 test when the movement speed is under the threshold
+     * @param testRunLocation
+     */
+    public void startDefaultAutomatedTest(Location testRunLocation) {
         // Sanity check
         if (iperf3TestRunning.get()) {
             Log.e(TAG, "Iperf3 test is still running! aborting...");

--- a/app/src/main/java/cloudcity/Iperf3Monitor.java
+++ b/app/src/main/java/cloudcity/Iperf3Monitor.java
@@ -563,7 +563,7 @@ public class Iperf3Monitor {
         cmdList.add(randomPortStr);
         // Add duration
         cmdList.add("-t");
-        String duration = "15";
+        String duration = String.valueOf(CloudCityConstants.CLOUD_CITY_IPERF3_TEST_DURATION_IN_SECONDS);
         cmdList.add(duration);
         // Protocol
         String protocol = "TCP";


### PR DESCRIPTION
Issue link:
https://github.com/Cloud-City-RS/cloud_city_platform/issues/760

Since our old default automated iperf3 test duration was 15, and we had to lower it to 10, this PR adjusts the few necessary constants to make that happen. Also, the old hardcoded duration of `"15"` was extracted into a new CloudCityConstants constant value.

On top of that, since we also had to change the speed threshold, those two constants were moved out of the `GPSMonitor` into the constants file, renamed for more descriptive naming to fit with the rest of the "automated iperf3 test"-related constants, and were put to use.

Finally, the iperf3 constants got their clarifying javadoc to distinguish between values used for prefilling the iperf3 screen and what's used for automated tests when the movement speed is below threshold.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new constants for iPerf3 testing configurations, enhancing settings and automated testing capabilities.
	- Updated the `Iperf3Monitor` to initiate dynamic automated tests based on new constants.

- **Bug Fixes**
	- Improved threshold handling in `GPSMonitor` to utilize updated constants for more accurate monitoring.

- **Documentation**
	- Updated documentation throughout the codebase to reflect new constants and method changes for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->