### PR TITLE
Fix sending cell info for iperf3

### DIFF
--- a/app/src/main/java/cloudcity/LoggingServiceExtensions.java
+++ b/app/src/main/java/cloudcity/LoggingServiceExtensions.java
@@ -5,7 +5,6 @@ import android.graphics.Color;
 import android.location.Location;
 import android.os.Handler;
 import android.os.HandlerThread;
-import android.telephony.CellInfo;
 import android.util.Log;
 import android.widget.ImageView;
 
@@ -16,14 +15,12 @@ import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import cloudcity.networking.CloudCityHelpers;
-import cloudcity.networking.models.CellInfoModel;
 import cloudcity.networking.models.MeasurementsModel;
 import cloudcity.networking.models.MobileSignalNetworkDataModel;
 import cloudcity.networking.models.NetworkDataModel;
 import cloudcity.networking.models.NetworkDataModelRequest;
 import cloudcity.util.CellUtil;
 import de.fraunhofer.fokus.OpenMobileNetworkToolkit.DataProvider.CellInformations.CellInformation;
-import de.fraunhofer.fokus.OpenMobileNetworkToolkit.DataProvider.CellInformations.GSMInformation;
 import de.fraunhofer.fokus.OpenMobileNetworkToolkit.DataProvider.DataProvider;
 import de.fraunhofer.fokus.OpenMobileNetworkToolkit.GlobalVars;
 import de.fraunhofer.fokus.OpenMobileNetworkToolkit.Preferences.SPType;
@@ -183,45 +180,10 @@ public class LoggingServiceExtensions {
         /* Convert to km/h */
         dataModel.setSpeed(location.getSpeed() * 3.6);
 
-        dataModel.setCellData(getCellInfoModel(category, currentCell));
+        dataModel.setCellData(
+                CellUtil.getCellInfoModel(currentCell)
+        );
 
         return dataModel;
-    }
-
-
-
-    private static @NonNull CellInfoModel getCellInfoModel(String category, CellInformation currentCell) {
-        CellInfoModel cellInfoModel = new CellInfoModel();
-
-        if (Objects.equals(category, "CDMA") || Objects.equals(category, "GSM")) {
-            /* No information in 2G and 3G set dummy data. */
-            cellInfoModel.setDummy(1);
-        } else {
-            /* Real data available for all other network types. */
-            if (currentCell instanceof GSMInformation) {
-                GSMInformation gsmCell = (GSMInformation) currentCell;
-                // Ok so bands is technically the ARFCN
-                String bandsString = gsmCell.getBands();
-                int arfcn = Integer.parseInt(bandsString);
-                cellInfoModel.setEarfcn(arfcn);
-                cellInfoModel.setPci(currentCell.getPci());
-            }
-        }
-
-        long id = currentCell.getCi();
-
-        if (Objects.equals(category, "NR")) {
-            if (id != CellInfo.UNAVAILABLE_LONG) {
-                cellInfoModel.setCellId(currentCell.getCi());
-            }
-        } else if (Objects.equals(category, "LTE")) {
-            if (id != CellInfo.UNAVAILABLE) {
-                cellInfoModel.setCellId((int)(currentCell.getCi() >> 8));
-                cellInfoModel.seteNodeBId((int) currentCell.getCi() & 0x000000FF);
-            }
-
-        }
-
-        return cellInfoModel;
     }
 }

--- a/app/src/main/java/cloudcity/networking/models/Iperf3NetworkDataModel.java
+++ b/app/src/main/java/cloudcity/networking/models/Iperf3NetworkDataModel.java
@@ -7,34 +7,32 @@ import androidx.annotation.NonNull;
 import com.google.gson.annotations.SerializedName;
 
 import cloudcity.dataholders.MetricsPOJO;
-import cloudcity.util.CloudCityUtil;
 
 public class Iperf3NetworkDataModel extends NetworkDataModel {
-    private static final int NUMBER_OF_DECIMALS_FOR_ACCURACY = 4;
-
     @SerializedName("category")
     final private String category = "Iperf3";
-
     @SerializedName("accuracy")
     private double accuracy;
     @SerializedName("speed")
     private double speed;
+    @SerializedName("cell_info")
+    private final CellInfoModel cellData;
 
     public Iperf3NetworkDataModel(
             @NonNull MetricsPOJO.UploadMetrics upload,
             @NonNull MetricsPOJO.DownloadMetrics download,
             @NonNull Location location,
-            @NonNull MeasurementsModel measurementsModel
+            @NonNull MeasurementsModel measurementsModel,
+            @NonNull CellInfoModel cellInfoModel
     ) {
         super(location.getLatitude(), location.getLongitude(), new Iperf3ValuesModel(upload, download, measurementsModel));
         this.accuracy = location.getAccuracy();
         this.speed = location.getSpeed();
+        this.cellData = cellInfoModel;
     }
 }
 
 class Iperf3ValuesModel extends NetworkDataModel.NetworkDataModelValues {
-    private static final int NUMBER_OF_DECIMALS_FOR_METRICS = 2;
-
     @SerializedName("upload_min")
     private final double ULmin;
     @SerializedName("upload_median")

--- a/app/src/main/java/cloudcity/util/CloudCityUtil.java
+++ b/app/src/main/java/cloudcity/util/CloudCityUtil.java
@@ -2,12 +2,14 @@ package cloudcity.util;
 
 import android.location.Location;
 import android.os.Build;
+import android.util.Pair;
 
 import androidx.annotation.NonNull;
 
 import cloudcity.CloudCityParamsRepository;
 import cloudcity.dataholders.MetricsPOJO;
 import cloudcity.networking.CloudCityHelpers;
+import cloudcity.networking.models.CellInfoModel;
 import cloudcity.networking.models.Iperf3NetworkDataModel;
 import cloudcity.networking.models.MeasurementsModel;
 import cloudcity.networking.models.NetworkDataModel;
@@ -46,7 +48,7 @@ public class CloudCityUtil {
     public static boolean sendIperf3Data(
             @NonNull MetricsPOJO metricsPOJO,
             @NonNull Location location,
-            @NonNull MeasurementsModel cellInfoMeasurements) {
+            @NonNull Pair<MeasurementsModel, CellInfoModel> cellInfoMeasurements) {
         MetricsPOJO.MetricsPair metricsPair = metricsPOJO.toMetricsPair();
         MetricsPOJO.UploadMetrics uploadMetrics = metricsPair.getUploadMetrics();
         MetricsPOJO.DownloadMetrics downloadMetrics = metricsPair.getDownloadMetrics();
@@ -55,7 +57,8 @@ public class CloudCityUtil {
                 uploadMetrics,
                 downloadMetrics,
                 location,
-                cellInfoMeasurements
+                cellInfoMeasurements.first,
+                cellInfoMeasurements.second
         );
         return CloudCityUtil.sendIperf3Data(iperf3Data);
     }


### PR DESCRIPTION
Issue link:
https://github.com/Cloud-City-RS/OMNTelcoMetrics/issues/39

Turns out, "cell info" was about the `"cell_info"` API parameter, and not the other stuff I've put in in #41 

Either way, this PR does some minor cleanup and consolidation, as well as moving the `getCellInfo()` from the `LoggingServiceExtensions` into the `CellUtil` where it kinda belongs.

Either way, the API returns correct responses, and the new request looks like this (minus the EARFCN due to being SIMless):
```
{
    "sensor_events": [
        {
            "accuracy": 12.166000366210938,
            "category": "Iperf3",
            "cell_info": {
                "cellId": 440,
                "eNodeBId": 6,
                "pci": 280
            },
            "speed": 0,
            "lat": 44.7483472,
            "lon": 20.4258946,
            "values": {
                "download_last": 8.388239016230942,
                "download_max": 8.388239016230942,
                "download_mean": 6.908275375018002,
                "download_median": 7.341265519762768,
                "download_min": 4.1954620696609375,
                "upload_last": 49.20704945121863,
                "upload_max": 49.20704945121863,
                "upload_mean": 37.69221902799094,
                "upload_median": 38.79339502049847,
                "upload_min": 23.06431407341595,
                "cell_type": 4,
                "rsrp": -107,
                "rsrq": -19,
                "rssnr": -2
            }
        }
    ]
}
```