### PR TITLE
Fix weird issue (or just me being SIM-less)

### DIFF
--- a/app/src/main/java/cloudcity/CloudCityConstants.java
+++ b/app/src/main/java/cloudcity/CloudCityConstants.java
@@ -1,5 +1,8 @@
 package cloudcity;
 
+import cloudcity.util.CellUtil;
+import de.fraunhofer.fokus.OpenMobileNetworkToolkit.DataProvider.CellInformations.CellInformation;
+
 /**
  * The "string holder" class for anything CloudCity related
  */
@@ -59,4 +62,10 @@ public class CloudCityConstants {
     public static final String CLOUD_CITY_IPERF3_TEST_TIME_THROTTLING_THRESHOLD = "cloud_city_iperf3_throttling_interval";
     // Iperf3 distance-based throttling shared pref key
     public static final String CLOUD_CITY_IPERF3_TEST_DISTANCE_THROTTLING_THRESHOLD = "cloud_city_iperf3_throttling_distance";
+
+    /**
+     * Whether {@link CellUtil#remapCellClassTypeIntoInteger(CellInformation)} should allow null cells to be
+     * remapped into 0 or not
+     */
+    public static final boolean ALLOW_TESTING_WITHOUT_SIM = false;
 }

--- a/app/src/main/java/cloudcity/util/CellUtil.java
+++ b/app/src/main/java/cloudcity/util/CellUtil.java
@@ -7,6 +7,7 @@ import androidx.annotation.NonNull;
 
 import java.util.List;
 
+import cloudcity.CloudCityConstants;
 import cloudcity.networking.models.CellInfoModel;
 import cloudcity.networking.models.MeasurementsModel;
 import de.fraunhofer.fokus.OpenMobileNetworkToolkit.DataProvider.CellInformations.CDMAInformation;
@@ -59,6 +60,15 @@ public class CellUtil {
         } else if (cellToRemap instanceof NRInformation) {
             retVal = 5;
         } else {
+            if (cellToRemap == null) {
+                if (CloudCityConstants.ALLOW_TESTING_WITHOUT_SIM) {
+                    CloudCityLogger.d(TAG, "We're allowed to test without SIM and we ran into a null cell! Returning 0");
+                    return 0;
+                } else {
+                    CloudCityLogger.e(TAG, "Ran into a null cell, and we're not allowed to test without SIM - something is going wrong here!");
+                    throw new IllegalStateException("Encountered a NULL cell in CellUtil::remapCellClassTypeIntoInteger!");
+                }
+            }
             CloudCityLogger.e(TAG, "Unsupported cell type: "+cellToRemap.getCellType());
             throw new IllegalStateException("Unsupported cell type encountered in CellUtil::remapCellClassTypeIntoInteger! cellType: "+cellToRemap.getCellType());
         }


### PR DESCRIPTION
Somehow, the cell was always null when it was supposed to be remapped into the number. This... shouldn't be because I don't have a SIM card. It used to work reliably regardless of that. It still works reliably after restarting the phone.

But, lets add this constant to allow null cells for some random unknown special (test) cases.

Worth mentioning that this didn't really help ressurect the sending, but the sending failure seems to be a different kind of server problem ATM. So lets let this one sit around for a while.