### PR TITLE
Change Iperf3 server to the new demo.staging one and send ping to API

### DIFF
--- a/app/src/main/java/cloudcity/CloudCityConstants.java
+++ b/app/src/main/java/cloudcity/CloudCityConstants.java
@@ -21,7 +21,7 @@ public class CloudCityConstants {
     /**
      * iPerf3 server to use for iperf3 tests; used for Settings screen prefilling as well as CloudCity automated tests
      */
-    public static final String CLOUD_CITY_IPERF3_SERVER = "demo.app.cloudcities.co";
+    public static final String CLOUD_CITY_IPERF3_SERVER = "demo.staging.cloudcities.co";
     /**
      * iPerf3 server port range to use for iperf3 tests, this one is the smaller of the two ports in the range;
      * used for Settings screen prefilling as well as CloudCity automated tests

--- a/app/src/main/java/cloudcity/dataholders/Iperf3MetricsPOJO.java
+++ b/app/src/main/java/cloudcity/dataholders/Iperf3MetricsPOJO.java
@@ -22,11 +22,24 @@ public class Iperf3MetricsPOJO {
     private final double ULmax;
     private final double ULlast;
 
+    private final double RTTmin;
+    private final double RTTmedian;
+    private final double RTTmean;
+    private final double RTTmax;
+    private final double RTTlast;
+
+    private final double PLmin;
+    private final double PLmedian;
+    private final double PLmean;
+    private final double PLmax;
+    private final double PLlast;
+
     private final long startTimestamp;
     private final long endTimestamp;
 
     /**
-     * The all arg constructor. Please prefer using the other {@link #Iperf3MetricsPOJO(DownloadMetrics, UploadMetrics, long, long)}
+     * The all arg constructor. Please prefer using the other
+     * {@link Iperf3MetricsPOJO#Iperf3MetricsPOJO(DownloadMetrics, UploadMetrics, PingMetricsPOJO.RTTMetrics, PingMetricsPOJO.PackageLossMetrics, long, long)}
      * over this one, as this one might be error-prone
      *
      * @param DLmin download min
@@ -39,11 +52,23 @@ public class Iperf3MetricsPOJO {
      * @param ULmean upload mean (middle element of the sampling list)
      * @param ULmax upload max
      * @param ULlast last upload sample
+     * @param RTTmin ping round-trip-time min
+     * @param RTTmedian ping round-trip-time median (average) of the whole sampling list
+     * @param RTTmean ping round-trip-time mean (middle element of the sampling list)
+     * @param RTTmax ping round-trip-time max
+     * @param RTTlast last ping round-trip-time sample
+     * @param PLmin ping package loss min
+     * @param PLmedian ping package loss median (average) of the whole sampling list
+     * @param PLmean ping package loss mean (middle element of the sampling list)
+     * @param PLmax ping package loss max
+     * @param PLlast last ping package loss sample
      * @param startTimestamp iperf3 test start timestamp
      * @param endTimestamp iperf3 test end timestamp
      */
     public Iperf3MetricsPOJO(double DLmin, double DLmedian, double DLmean, double DLmax, double DLlast,
                              double ULmin, double ULmedian, double ULmean, double ULmax, double ULlast,
+                             double RTTmin, double RTTmedian, double RTTmean, double RTTmax, double RTTlast,
+                             double PLmin, double PLmedian, double PLmean, double PLmax, double PLlast,
                              long startTimestamp, long endTimestamp) {
         this.DLmin = DLmin;
         this.DLmedian = DLmedian;
@@ -55,6 +80,18 @@ public class Iperf3MetricsPOJO {
         this.ULmean = ULmean;
         this.ULmax = ULmax;
         this.ULlast = ULlast;
+        // ping stuff
+        this.RTTmin = RTTmin;
+        this.RTTmedian = RTTmedian;
+        this.RTTmean = RTTmean;
+        this.RTTmax = RTTmax;
+        this.RTTlast = RTTlast;
+        this.PLmin = PLmin;
+        this.PLmedian = PLmedian;
+        this.PLmean = PLmean;
+        this.PLmax = PLmax;
+        this.PLlast = PLlast;
+        // timestamp
         this.startTimestamp = startTimestamp;
         this.endTimestamp = endTimestamp;
     }
@@ -64,7 +101,14 @@ public class Iperf3MetricsPOJO {
      * @param download the download metrics
      * @param upload the upload metrics
      */
-    public Iperf3MetricsPOJO(DownloadMetrics download, UploadMetrics upload, long startTimestamp, long endTimestamp) {
+    public Iperf3MetricsPOJO(
+            DownloadMetrics download,
+            UploadMetrics upload,
+            PingMetricsPOJO.RTTMetrics pingRttMetrics,
+            PingMetricsPOJO.PackageLossMetrics pingPLmetrics,
+            long startTimestamp,
+            long endTimestamp
+    ) {
         this(
                 download.getDLmin(),
                 download.getDLmedian(),
@@ -76,6 +120,16 @@ public class Iperf3MetricsPOJO {
                 upload.getULmean(),
                 upload.getULmax(),
                 upload.getULlast(),
+                pingRttMetrics.getMin(),
+                pingRttMetrics.getMedian(),
+                pingRttMetrics.getMean(),
+                pingRttMetrics.getMax(),
+                pingRttMetrics.getLast(),
+                pingPLmetrics.getMin(),
+                pingPLmetrics.getMedian(),
+                pingPLmetrics.getMean(),
+                pingPLmetrics.getMax(),
+                pingPLmetrics.getLast(),
                 startTimestamp,
                 endTimestamp
         );
@@ -85,6 +139,13 @@ public class Iperf3MetricsPOJO {
         return new MetricsPair(
                 new UploadMetrics(ULmin, ULmedian, ULmean, ULmax, ULlast),
                 new DownloadMetrics(DLmin, DLmedian, DLmean, DLmax, DLlast)
+        );
+    }
+
+    public PingMetricsPOJO.MetricsPair toPingMetricsPair() {
+        return new PingMetricsPOJO.MetricsPair(
+                new PingMetricsPOJO.RTTMetrics(RTTmin, RTTmedian, RTTmean, RTTmax, RTTlast),
+                new PingMetricsPOJO.PackageLossMetrics(PLmin, PLmedian, PLmean, PLmax, PLlast)
         );
     }
 

--- a/app/src/main/java/cloudcity/dataholders/PingMetricsPOJO.java
+++ b/app/src/main/java/cloudcity/dataholders/PingMetricsPOJO.java
@@ -162,11 +162,51 @@ public class PingMetricsPOJO {
         public RTTMetrics(double min, double median, double mean, double max, double last) {
             super(min, median, mean, max, last);
         }
+
+        public double getRTTmin() {
+            return getMin();
+        }
+
+        public double getRTTmedian() {
+            return getMedian();
+        }
+
+        public double getRTTmean() {
+            return getMean();
+        }
+
+        public double getRTTmax() {
+            return getMax();
+        }
+
+        public double getRTTlast() {
+            return getLast();
+        }
     }
 
     public static class PackageLossMetrics extends BaseMetrics {
         public PackageLossMetrics(double min, double median, double mean, double max, double last) {
             super(min,median,mean,max,last);
+        }
+
+        public double getPLmin() {
+            return getMin();
+        }
+
+        public double getPLmedian() {
+            return getMedian();
+        }
+
+        public double getPLmean() {
+            return getMean();
+        }
+
+        public double getPLmax() {
+            return getMax();
+        }
+
+        public double getPLlast() {
+            return getLast();
         }
     }
 }

--- a/app/src/main/java/cloudcity/networking/models/Iperf3NetworkDataModel.java
+++ b/app/src/main/java/cloudcity/networking/models/Iperf3NetworkDataModel.java
@@ -7,6 +7,7 @@ import androidx.annotation.NonNull;
 import com.google.gson.annotations.SerializedName;
 
 import cloudcity.dataholders.Iperf3MetricsPOJO;
+import cloudcity.dataholders.PingMetricsPOJO;
 
 public class Iperf3NetworkDataModel extends NetworkDataModel {
     @SerializedName("category")
@@ -21,11 +22,17 @@ public class Iperf3NetworkDataModel extends NetworkDataModel {
     public Iperf3NetworkDataModel(
             @NonNull Iperf3MetricsPOJO.UploadMetrics upload,
             @NonNull Iperf3MetricsPOJO.DownloadMetrics download,
+            @NonNull PingMetricsPOJO.RTTMetrics rttMetrics,
+            @NonNull PingMetricsPOJO.PackageLossMetrics packageLossMetrics,
             @NonNull Location location,
             @NonNull MeasurementsModel measurementsModel,
             @NonNull CellInfoModel cellInfoModel
     ) {
-        super(location.getLatitude(), location.getLongitude(), new Iperf3ValuesModel(upload, download, measurementsModel));
+        super(
+                location.getLatitude(),
+                location.getLongitude(),
+                new Iperf3ValuesModel(upload, download, rttMetrics, packageLossMetrics, measurementsModel)
+        );
         this.accuracy = location.getAccuracy();
         this.speed = location.getSpeed();
         this.cellData = cellInfoModel;
@@ -55,6 +62,29 @@ class Iperf3ValuesModel extends NetworkDataModel.NetworkDataModelValues {
     @SerializedName("download_last")
     private final double DLlast;
 
+    // ping details
+    @SerializedName("ping_RTT_min")
+    private final double RTTmin;
+    @SerializedName("ping_RTT_median")
+    private final double RTTmedian;
+    @SerializedName("ping_RTT_mean")
+    private final double RTTmean;
+    @SerializedName("ping_RTT_max")
+    private final double RTTmax;
+    @SerializedName("ping_RTT_last")
+    private final double RTTlast;
+
+    @SerializedName("ping_package_loss_min")
+    private final double PLmin;
+    @SerializedName("ping_package_loss_median")
+    private final double PLmedian;
+    @SerializedName("ping_package_loss_mean")
+    private final double PLmean;
+    @SerializedName("ping_package_loss_max")
+    private final double PLmax;
+    @SerializedName("ping_package_loss_last")
+    private final double PLlast;
+
     @SerializedName("cell_type")
     private final int cellType;
 
@@ -73,6 +103,8 @@ class Iperf3ValuesModel extends NetworkDataModel.NetworkDataModelValues {
 
     public Iperf3ValuesModel(@NonNull Iperf3MetricsPOJO.UploadMetrics upload,
                              @NonNull Iperf3MetricsPOJO.DownloadMetrics download,
+                             @NonNull PingMetricsPOJO.RTTMetrics rttMetrics,
+                             @NonNull PingMetricsPOJO.PackageLossMetrics packageLossMetrics,
                              @NonNull MeasurementsModel cellMeasurements) {
         ULmin = upload.getULmin();
         ULmedian = upload.getULmedian();
@@ -85,6 +117,18 @@ class Iperf3ValuesModel extends NetworkDataModel.NetworkDataModelValues {
         DLmean = download.getDLmean();
         DLmax = download.getDLmax();
         DLlast = download.getDLlast();
+
+        RTTmin = rttMetrics.getRTTmin();
+        RTTmedian = rttMetrics.getRTTmedian();
+        RTTmean = rttMetrics.getRTTmean();
+        RTTmax = rttMetrics.getRTTmax();
+        RTTlast = rttMetrics.getRTTlast();
+
+        PLmin = packageLossMetrics.getPLmin();
+        PLmedian = packageLossMetrics.getPLmedian();
+        PLmean = packageLossMetrics.getPLmean();
+        PLmax = packageLossMetrics.getPLmax();
+        PLlast = packageLossMetrics.getPLlast();
 
         rsrp = cellMeasurements.getRsrp();
         rsrq = cellMeasurements.getRsrq();

--- a/app/src/main/java/cloudcity/util/CloudCityUtil.java
+++ b/app/src/main/java/cloudcity/util/CloudCityUtil.java
@@ -10,6 +10,7 @@ import java.util.List;
 
 import cloudcity.CloudCityParamsRepository;
 import cloudcity.dataholders.Iperf3MetricsPOJO;
+import cloudcity.dataholders.PingMetricsPOJO;
 import cloudcity.networking.CloudCityHelpers;
 import cloudcity.networking.models.CellInfoModel;
 import cloudcity.networking.models.Iperf3NetworkDataModel;
@@ -54,10 +55,16 @@ public class CloudCityUtil {
         Iperf3MetricsPOJO.MetricsPair metricsPair = metricsPOJO.toMetricsPair();
         Iperf3MetricsPOJO.UploadMetrics uploadMetrics = metricsPair.getUploadMetrics();
         Iperf3MetricsPOJO.DownloadMetrics downloadMetrics = metricsPair.getDownloadMetrics();
+        PingMetricsPOJO.MetricsPair pingMetricsPair = metricsPOJO.toPingMetricsPair();
+        PingMetricsPOJO.RTTMetrics rttMetrics = pingMetricsPair.getRTTMetrics();
+        PingMetricsPOJO.PackageLossMetrics packageLossMetrics = pingMetricsPair.getPackageLossMetrics();
+
 
         Iperf3NetworkDataModel iperf3Data = new Iperf3NetworkDataModel(
                 uploadMetrics,
                 downloadMetrics,
+                rttMetrics,
+                packageLossMetrics,
                 location,
                 cellInfoMeasurements.first,
                 cellInfoMeasurements.second


### PR DESCRIPTION
This PR changes the iperf3 server to the new `demo.staging.cloudcities.co`.

Should have been done by #53 but oh well. Will get a better chance of consolidation when all networking is actually using the same base server URL.

**UPDATE**: the iperf3  fixes were moved to #55 because i had second-thoughts whether it all works fine, and having tested with 0 time between tests has somewhat weakened my confidence in whether it all works fine as it should

The new iPerf3 API payload looks like this:
```
{
    "sensor_events": [
        {
            "accuracy": 12.939000129699707,
            "category": "Iperf3",
            "cell_info": {
                "cellId": 440,
                "eNodeBId": 6,
                "pci": 280
            },
            "speed": 0.07587698101997375,
            "lat": 44.7483396,
            "lon": 20.4259102,
            "values": {
                "download_last": 3.146857718067403,
                "download_max": 3.146857718067403,
                "download_mean": 2.4715820372784556,
                "download_median": 2.6998518480278184,
                "download_min": 1.04848163349327,
                "ping_package_loss_last": 0,
                "ping_package_loss_max": 0,
                "ping_package_loss_mean": 0,
                "ping_package_loss_median": 0,
                "ping_package_loss_min": 0,
                "ping_RTT_last": 341,
                "ping_RTT_max": 291.4,
                "ping_RTT_mean": 341,
                "ping_RTT_median": 320,
                "ping_RTT_min": 162,
                "upload_last": 13.636383444958746,
                "upload_max": 13.636383444958746,
                "upload_mean": 9.365987809933559,
                "upload_median": 9.436683401555813,
                "upload_min": 3.145564508497512,
                "cell_type": 4,
                "rsrp": -107,
                "rsrq": -17,
                "rssnr": -1
            }
        }
    ]
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Updated server URL for iPerf3 tests to improve testing accuracy.
	- Enhanced metrics collection for round-trip time (RTT) and packet loss in network performance data.
	- Added new methods for easier access to RTT and packet loss metrics.

- **Bug Fixes**
	- Improved error handling for file access in the iPerf3 parser.

- **Improvements**
	- Enhanced thread safety in the PingParser class to ensure reliable parsing operations.
	- Refined logic in the Iperf3Monitor for better test execution management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->