### PR TITLE
Move iperf3 fixes out of server change

### DIFF
--- a/app/src/main/java/cloudcity/Iperf3Monitor.java
+++ b/app/src/main/java/cloudcity/Iperf3Monitor.java
@@ -21,7 +21,6 @@ import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -32,16 +31,16 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Random;
 import java.util.UUID;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import cloudcity.dataholders.Iperf3RunnerData;
 import cloudcity.dataholders.Iperf3MetricsPOJO;
+import cloudcity.dataholders.Iperf3RunnerData;
 import cloudcity.dataholders.PingMetricsPOJO;
 import cloudcity.util.CloudCityLogger;
 import cloudcity.util.CloudCityUtil;
 import de.fraunhofer.fokus.OpenMobileNetworkToolkit.Iperf3.Iperf3Fragment;
 import de.fraunhofer.fokus.OpenMobileNetworkToolkit.Iperf3.Iperf3Parser;
+import de.fraunhofer.fokus.OpenMobileNetworkToolkit.Iperf3.Iperf3ParserNoFileToReadException;
 import de.fraunhofer.fokus.OpenMobileNetworkToolkit.Iperf3.Iperf3ResultsDataBase;
 import de.fraunhofer.fokus.OpenMobileNetworkToolkit.Iperf3.Iperf3RunResult;
 import de.fraunhofer.fokus.OpenMobileNetworkToolkit.Iperf3.Iperf3RunResultDao;
@@ -275,7 +274,7 @@ public class Iperf3Monitor {
                     Iperf3Parser iperf3Parser = null;
                     try {
                         iperf3Parser = Iperf3Parser.instantiate(targetFilePath);
-                    } catch (FileNotFoundException e) {
+                    } catch (Iperf3ParserNoFileToReadException e) {
                         CloudCityLogger.e(TAG, "Exception " + e + " happened during iperf3 parser instantiation!", e);
                         throw new RuntimeException(e);
                     }

--- a/app/src/main/java/cloudcity/Iperf3Monitor.java
+++ b/app/src/main/java/cloudcity/Iperf3Monitor.java
@@ -839,7 +839,7 @@ public class Iperf3Monitor {
         long now = System.currentTimeMillis();
         long diffToLastTestInMillis = now - testStartTimestamp;
         long diffInSeconds = diffToLastTestInMillis / 1000L;
-        return diffInSeconds <= THROTTLING_THRESHOLD_IN_SECONDS;
+        return diffInSeconds < THROTTLING_THRESHOLD_IN_SECONDS;
     }
 
     /**

--- a/app/src/main/java/cloudcity/Iperf3Monitor.java
+++ b/app/src/main/java/cloudcity/Iperf3Monitor.java
@@ -588,7 +588,15 @@ public class Iperf3Monitor {
                 // Nuke the last running test
                 CloudCityLogger.v(TAG, "Cancelling last work UID "+lastEmissionFromDatabaseWorkUID+" from WorkManager");
                 getWorkManager().cancelAllWorkByTag(lastEmissionFromDatabaseWorkUID);
-                // Nuke everything else iperf3-related from the WorkManager
+                // Cancel all of the UIDs actually
+                List<String> workerUIDs = iperf3ResultsDatabase.iperf3RunResultDao().getIDs();
+                CloudCityLogger.v(TAG, "Cancelling list of UIDs: "+workerUIDs+" from WorkManager");
+                for(String workerUID : workerUIDs) {
+                    // While we *could* use cancelAllWorkByUUID(), we won't because we are adding their UUIDs
+                    // as Worker tags via addTag() when enqueue()-ing them onto the WorkManager
+                    getWorkManager().cancelAllWorkByTag(workerUID);
+                }
+                // Nuke everything else iperf3-related from the WorkManager - would be great to just use cancelAllWork() but that will kill more than just iperf3
                 // JUST MAKE SURE THESE ARE THE SAME AS IN Iperf3Fragment for enqueue() methods calls in executeIperfCommand()!!!
                 CloudCityLogger.v(TAG, "Cancelling ALL Workers with the three tags from WorkManager");
                 getWorkManager().cancelAllWorkByTag("iperf3Run");

--- a/app/src/main/java/cloudcity/Iperf3Monitor.java
+++ b/app/src/main/java/cloudcity/Iperf3Monitor.java
@@ -839,7 +839,7 @@ public class Iperf3Monitor {
         long now = System.currentTimeMillis();
         long diffToLastTestInMillis = now - testStartTimestamp;
         long diffInSeconds = diffToLastTestInMillis / 1000L;
-        return diffInSeconds < THROTTLING_THRESHOLD_IN_SECONDS;
+        return diffInSeconds <= THROTTLING_THRESHOLD_IN_SECONDS;
     }
 
     /**

--- a/app/src/main/java/cloudcity/PingMonitor.java
+++ b/app/src/main/java/cloudcity/PingMonitor.java
@@ -180,9 +180,8 @@ public class PingMonitor {
         rttMetric.createMainLL("RTT [ms]");
         packetLossMetric.createMainLL("Packet Loss [%]");
 
-        pingParser = PingParser.getInstance(null);
         CloudCityLogger.v(TAG, "Adding property change listener");
-        pingParser.addPropertyChangeListener(evt -> {
+        PingParser.addExternalPropertyChangeListener(evt -> {
             PingInformation pi = (PingInformation) evt.getNewValue();
 //            CloudCityLogger.v(TAG, "propertyChange: "+pi+"\tline type: "+pi.getLineType());
             switch (pi.getLineType()) {

--- a/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/Iperf3/Iperf3Fragment.java
+++ b/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/Iperf3/Iperf3Fragment.java
@@ -490,12 +490,14 @@ public class Iperf3Fragment extends Fragment {
                 .Builder(Iperf3ToLineProtocolWorker.class)
                 .setInputData(iperf3Data.build())
                 .addTag("iperf3LineProtocol")
+                .addTag(iperf3WorkerID)
                 .build();
         OneTimeWorkRequest iperf3UP =
             new OneTimeWorkRequest
                 .Builder(Iperf3UploadWorker.class)
                 .setInputData(iperf3Data.build())
                 .addTag("iperf3")
+                .addTag(iperf3WorkerID)
                 .build();
 
         iperf3RunResultDao.insert(

--- a/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/Iperf3/Iperf3Fragment.java
+++ b/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/Iperf3/Iperf3Fragment.java
@@ -489,6 +489,7 @@ public class Iperf3Fragment extends Fragment {
             new OneTimeWorkRequest
                 .Builder(Iperf3ToLineProtocolWorker.class)
                 .setInputData(iperf3Data.build())
+                .addTag("iperf3LineProtocol")
                 .build();
         OneTimeWorkRequest iperf3UP =
             new OneTimeWorkRequest

--- a/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/Iperf3/Iperf3LogFragment.java
+++ b/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/Iperf3/Iperf3LogFragment.java
@@ -103,7 +103,12 @@ public class Iperf3LogFragment extends Fragment {
             }
             String line;
 
-            Iperf3Parser iperf3Parser = new Iperf3Parser(iperf3RunResult.input.iperf3rawIperf3file);
+            Iperf3Parser iperf3Parser = null;
+            try {
+                iperf3Parser = new Iperf3Parser(iperf3RunResult.input.iperf3rawIperf3file);
+            } catch (Iperf3ParserNoFileToReadException e) {
+                throw new RuntimeException(e);
+            }
             iperf3Parser.addPropertyChangeListener(new PropertyChangeListener() {
 
                 private void parseSum(Sum sum, Metric throughput){

--- a/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/Iperf3/Iperf3Parser.java
+++ b/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/Iperf3/Iperf3Parser.java
@@ -16,7 +16,6 @@ import de.fraunhofer.fokus.OpenMobileNetworkToolkit.Iperf3.JSON.Error;
 import de.fraunhofer.fokus.OpenMobileNetworkToolkit.Iperf3.JSON.Interval.Interval;
 import de.fraunhofer.fokus.OpenMobileNetworkToolkit.Iperf3.JSON.start.Start;
 
-
 public class Iperf3Parser {
     private static final String TAG = Iperf3Parser.class.getSimpleName();
 
@@ -35,11 +34,11 @@ public class Iperf3Parser {
     private Start start;
     private final Intervals intervals = new Intervals();
 
-    public static Iperf3Parser instantiate(@NonNull String pathToFile) throws FileNotFoundException {
+    public static Iperf3Parser instantiate(@NonNull String pathToFile) throws Iperf3ParserNoFileToReadException {
         return new Iperf3Parser(pathToFile);
     }
 
-    Iperf3Parser(String pathToFile) throws FileNotFoundException {
+    Iperf3Parser(String pathToFile) throws Iperf3ParserNoFileToReadException {
         this.pathToFile = pathToFile;
         this.file = new File(this.pathToFile);
         try {
@@ -47,7 +46,7 @@ public class Iperf3Parser {
         } catch (FileNotFoundException ex) {
             System.out.println("File not found");
             CloudCityLogger.e(TAG, "File not found!!! Path to file: "+pathToFile, ex);
-            return;
+            throw new Iperf3ParserNoFileToReadException(ex);
         }
         this.support = new PropertyChangeSupport(this);
     }

--- a/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/Iperf3/Iperf3Parser.java
+++ b/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/Iperf3/Iperf3Parser.java
@@ -35,11 +35,11 @@ public class Iperf3Parser {
     private Start start;
     private final Intervals intervals = new Intervals();
 
-    public static Iperf3Parser instantiate(@NonNull String pathToFile) {
+    public static Iperf3Parser instantiate(@NonNull String pathToFile) throws FileNotFoundException {
         return new Iperf3Parser(pathToFile);
     }
 
-    Iperf3Parser(String pathToFile) {
+    Iperf3Parser(String pathToFile) throws FileNotFoundException {
         this.pathToFile = pathToFile;
         this.file = new File(this.pathToFile);
         try {

--- a/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/Iperf3/Iperf3ParserNoFileToReadException.java
+++ b/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/Iperf3/Iperf3ParserNoFileToReadException.java
@@ -1,0 +1,12 @@
+package de.fraunhofer.fokus.OpenMobileNetworkToolkit.Iperf3;
+
+/**
+ * Exception thrown when {@link Iperf3Parser} encounters a {@link java.io.FileNotFoundException}
+ * during construction in {@link Iperf3Parser#Iperf3Parser(String)}
+ */
+public class Iperf3ParserNoFileToReadException extends Exception {
+
+    Iperf3ParserNoFileToReadException(Exception exception) {
+        super(exception);
+    }
+}

--- a/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/Iperf3/Iperf3ToLineProtocolWorker.java
+++ b/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/Iperf3/Iperf3ToLineProtocolWorker.java
@@ -145,7 +145,13 @@ public class Iperf3ToLineProtocolWorker extends Worker {
         setup();
         Data output = new Data.Builder().putBoolean("iperf3_upload", false).build();
 
-        Iperf3Parser iperf3Parser = new Iperf3Parser(rawIperf3file);
+        Iperf3Parser iperf3Parser = null;
+        try {
+            iperf3Parser = new Iperf3Parser(rawIperf3file);
+        } catch (Iperf3ParserNoFileToReadException e) {
+            // Instead of rethrowing, just finish in failure and that's that.
+            return Result.failure();
+        }
         iperf3Parser.parse();
 
 

--- a/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/Metric/Metric.java
+++ b/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/Metric/Metric.java
@@ -11,9 +11,12 @@ import java.util.ArrayList;
 import java.util.Locale;
 import java.util.OptionalDouble;
 
+import cloudcity.util.CloudCityLogger;
 import de.fraunhofer.fokus.OpenMobileNetworkToolkit.R;
 
 public class Metric {
+    private static final String TAG = "Metric";
+
         private LinearLayout mean;
         private LinearLayout median;
         private LinearLayout max;
@@ -26,6 +29,8 @@ public class Metric {
         private final METRIC_TYPE metricType;
         private final Context ct;
         private LinearLayout mainLL;
+
+        private String mainLLdirection;
 
         public Metric(METRIC_TYPE metricType, Context ct){
                 this.metricType = metricType;
@@ -106,6 +111,7 @@ public class Metric {
             return Double.toString(value);
         }
         public LinearLayout createMainLL(String direction) {
+            mainLLdirection = direction;
             mainLL = new LinearLayout(ct);
             LinearLayout.LayoutParams foo1 = new LinearLayout.LayoutParams(
                 LinearLayout.LayoutParams.MATCH_PARENT,
@@ -172,6 +178,18 @@ public class Metric {
         public void update(Double value){
             this.meanList.add(value);
 
+            try {
+                updateViews(value);
+            } catch(NullPointerException npe) {
+                CloudCityLogger.e(TAG, "NullPointerException happened while trying to update views with direction " + mainLLdirection + " for value: " + value + "...\treinitializing views and retrying.", npe);
+                // In case the views are missing, we should just reinitialize them, and try updating again
+                createMainLL(mainLLdirection);
+            } finally {
+                updateViews(value);
+            }
+        }
+
+        private void updateViews(Double value) {
             ((TextView)mean.getChildAt(1)).setText(String.format(" %s", getFormatedString(calcMean())));
             ((TextView)median.getChildAt(1)).setText(String.format(" %s", getFormatedString(calcMedian())));
             ((TextView)max.getChildAt(1)).setText(String.format(" %s", getFormatedString(calcMax())));

--- a/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/Ping/PingParser.java
+++ b/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/Ping/PingParser.java
@@ -1,9 +1,12 @@
 package de.fraunhofer.fokus.OpenMobileNetworkToolkit.Ping;
 
+import androidx.annotation.Nullable;
+
 import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeSupport;
 import java.io.BufferedReader;
 import java.io.IOException;
+import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 
 import cloudcity.util.CloudCityLogger;
@@ -16,22 +19,37 @@ public class PingParser {
     private static final String TAG = "PingParser";
 
     private static PingParser instance = null;
-    private BufferedReader br;
+    private volatile BufferedReader br;
     private final ArrayList<PingInformation> lines;
 
     private final PropertyChangeSupport support;
     private PropertyChangeListener listener;
+
+    private static @Nullable WeakReference<PropertyChangeListener> externalPropertyChangeListener;
     private PingParser(BufferedReader br) {
         this.br = br;
         this.lines = new ArrayList<>();
         support = new PropertyChangeSupport(this);
+        if (externalPropertyChangeListener != null && externalPropertyChangeListener.get() != null) {
+            addPropertyChangeListener(externalPropertyChangeListener.get());
+        }
     }
 
-    public static PingParser getInstance(BufferedReader br){
-        if (instance == null) instance = new PingParser(br);
-        if(br != null); instance.setBr(br);
+    public static synchronized PingParser getInstance(BufferedReader br){
+        if (instance == null) {
+            synchronized (PingParser.class) {
+                if (instance == null) {
+                    instance = new PingParser(br);
+                    CloudCityLogger.v(TAG, "Instantiated PingParser with BufferedReader "+br);
+                }
+            }
+        }
+        if (br != null) {
+            instance.setBr(br);
+        }
         return instance;
     }
+
     private LINEType getLineType(String line){
 //        CloudCityLogger.d(TAG, "--> getLineType()\tline: "+line);
         if (line.contains("bytes from")) {
@@ -47,7 +65,7 @@ public class PingParser {
             return LINEType.UNKNOWN;
         }
     }
-    public void parse(){
+    public synchronized void parse(){
         String line;
         try {
             while((line = this.br.readLine()) != null){
@@ -80,6 +98,11 @@ public class PingParser {
     public void addPropertyChangeListener(PropertyChangeListener listener){
         support.addPropertyChangeListener(listener);
     }
+
+    public static synchronized void addExternalPropertyChangeListener(@Nullable PropertyChangeListener listener){
+        externalPropertyChangeListener = new WeakReference<>(listener);
+    }
+
     public void setListener(PropertyChangeListener listener){
         this.listener = listener;
     }

--- a/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/Ping/PingWorker.java
+++ b/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/Ping/PingWorker.java
@@ -30,6 +30,7 @@ import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -177,10 +178,12 @@ public class PingWorker extends Worker {
             parsePingCommand();
             pingProcess = runtime.exec(stringBuilder.toString());
 
+            InputStream pingProcessInputStream = pingProcess.getInputStream();
+            if (pingProcessInputStream == null) {
+                CloudCityLogger.w(TAG, "Ping process input stream was NULL!");
+            }
             BufferedReader outputReader =
-                new BufferedReader(new InputStreamReader(pingProcess.getInputStream()));
-
-
+                new BufferedReader(new InputStreamReader(pingProcessInputStream));
 
             PingParser pingParser = PingParser.getInstance(outputReader);
 


### PR DESCRIPTION
This PR fixes a shitload about iperf3 stability and the whole iperf3Monitor "locking up" or getting dumb because (actually not hearing emissions taht we're listening to, or them not reaching our listeners) but it also fixes a flaw introduced in the Iperf3Parser by the initial Iperf3Monitor implementation which initialized it with a blank reader, which could cause Iperf3Workers to get dumbed out down the line. tl;dr - things have considerably improved and we won't have any more situations of iperf3 not being sent for many miles :)

I've moved them out of #54 because... well, i'm not super-sure everything works super-great when i reduce the waiting period to 0, but seems to work fine at 6 seconds.