### PR TITLE
Fix iPerf3 API payload by moving the (signal/cell) measurements out of 'values'

### DIFF
--- a/app/src/main/java/cloudcity/networking/models/CellInfoModel.java
+++ b/app/src/main/java/cloudcity/networking/models/CellInfoModel.java
@@ -3,6 +3,8 @@ package cloudcity.networking.models;
 import com.google.gson.annotations.SerializedName;
 import android.telephony.CellInfo;
 
+import androidx.annotation.Nullable;
+
 public class CellInfoModel {
 
     private Integer earfcn;
@@ -12,7 +14,11 @@ public class CellInfoModel {
     @SerializedName("dummy_cell_info")
     private Integer dummy;
 
-    public int getEarfcn() {
+    /**
+     * Returns the 'bands' (EARFCN)
+     * @return the earfcn or null if it wasn't present (no SIM or not on any cell)
+     */
+    public @Nullable Integer getEarfcn() {
         return earfcn;
     }
 

--- a/app/src/main/java/cloudcity/networking/models/ExtendedCellInfoModel.java
+++ b/app/src/main/java/cloudcity/networking/models/ExtendedCellInfoModel.java
@@ -1,0 +1,224 @@
+package cloudcity.networking.models;
+
+import android.telephony.CellInfo;
+
+import androidx.annotation.NonNull;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * Class combining {@link CellInfoModel} and {@link MeasurementsModel} into one
+ */
+public class ExtendedCellInfoModel {
+
+    private Integer earfcn;
+    private Integer pci;
+    private Long cellId;
+    private Integer eNodeBId;
+    @SerializedName("dummy_cell_info")
+    private Integer dummyCell;
+
+    // LTE
+    private Integer rsrp;
+    private Integer rsrq;
+    private Integer rssnr;
+
+    // 5G
+    private Integer csirsrp;
+    private Integer csirsrq;
+    private Integer csisinr;
+    private Integer ssrsrp;
+    private Integer ssrsrq;
+    private Integer sssinr;
+
+    @SerializedName("dummy_value")
+    private Integer dummyMeasurement;
+
+    @SerializedName("cell_type")
+    private int cellType;
+
+    public ExtendedCellInfoModel(
+            @NonNull MeasurementsModel measurementsModel,
+            @NonNull CellInfoModel cellInfoModel
+    ) {
+        super();
+
+        // Measurements stuff
+        setCsirsrp(measurementsModel.getCsirsrp());
+        setCsirsrq(measurementsModel.getCsirsrq());
+        setCsisinr(measurementsModel.getCsisinr());
+        setSsrsrp(measurementsModel.getSsrsrp());
+        setSsrsrq(measurementsModel.getSsrsrq());
+        setSssinr(measurementsModel.getSssinr());
+
+        setRsrp(measurementsModel.getRsrp());
+        setRsrq(measurementsModel.getRsrq());
+        setRssnr(measurementsModel.getRssnr());
+
+        setCellType(measurementsModel.getCellType());
+        setDummyMeasurement(measurementsModel.getDummy());
+
+        // Cell info stuff
+        setEarfcn(cellInfoModel.getEarfcn());
+        setPci(cellInfoModel.getPci());
+        setCellId(cellInfoModel.getCellId());
+        setDummyCell(cellInfoModel.getDummy());
+    }
+
+    public int getEarfcn() {
+        return earfcn;
+    }
+
+    public void setEarfcn(Integer earfcn) {
+        if (earfcn == null || earfcn == CellInfo.UNAVAILABLE) {
+            return;
+        }
+        this.earfcn = earfcn;
+    }
+
+    public int getPci() {
+        return pci;
+    }
+
+    public void setPci(Integer pci) {
+        if (pci == null || pci == CellInfo.UNAVAILABLE) {
+            return;
+        }
+        this.pci = pci;
+    }
+
+    public long getCellId() {
+        return cellId;
+    }
+
+    public void setCellId(long cellId) {
+        this.cellId = cellId;
+    }
+
+    public int geteNodeBId() {
+        return eNodeBId;
+    }
+
+    public void seteNodeBId(int eNodeBId) {
+        this.eNodeBId = eNodeBId;
+    }
+
+    public Integer getDummyCell() {
+        return dummyCell;
+    }
+
+    public void setDummyCell(Integer dummy) {
+        this.dummyCell = dummy;
+    }
+
+    public Integer getRsrp() {
+        return rsrp;
+    }
+
+    public void setRsrp(Integer rsrp) {
+        if (rsrp == null || rsrp == CellInfo.UNAVAILABLE) {
+            return;
+        }
+        this.rsrp = rsrp;
+    }
+
+    public Integer getRsrq() {
+        return rsrq;
+    }
+
+    public void setRsrq(Integer rsrq) {
+        if (rsrq == null || rsrq == CellInfo.UNAVAILABLE) {
+            return;
+        }
+        this.rsrq = rsrq;
+    }
+
+    public Integer getRssnr() {
+        return rssnr;
+    }
+
+    public void setRssnr(Integer rssnr) {
+        if (rssnr == null || rssnr == CellInfo.UNAVAILABLE) {
+            return;
+        }
+        this.rssnr = rssnr;
+    }
+
+    public Integer getCsirsrp() {
+        return csirsrp;
+    }
+
+    public void setCsirsrp(Integer csirsrp) {
+        if (csirsrp == null || csirsrp == CellInfo.UNAVAILABLE) {
+            return;
+        }
+        this.csirsrp = csirsrp;
+    }
+
+    public Integer getCsirsrq() {
+        return csirsrq;
+    }
+
+    public void setCsirsrq(Integer csirsrq) {
+        if (csirsrq == null || csirsrq == CellInfo.UNAVAILABLE) {
+            return;
+        }
+        this.csirsrq = csirsrq;
+    }
+
+    public Integer getCsisinr() {
+        return csisinr;
+    }
+
+    public void setCsisinr(Integer csisinr) {
+        if (csisinr == null || csisinr == CellInfo.UNAVAILABLE) {
+            return;
+        }
+        this.csisinr = csisinr;
+    }
+
+    public Integer getSsrsrp() {
+        return ssrsrp;
+    }
+
+    public void setSsrsrp(Integer ssrsrp) {
+        if (ssrsrp == null || ssrsrp == CellInfo.UNAVAILABLE) {
+            return;
+        }
+        this.ssrsrp = ssrsrp;
+    }
+
+    public Integer getSsrsrq() {
+        return ssrsrq;
+    }
+
+    public void setSsrsrq(Integer ssrsrq) {
+        if (ssrsrq == null || ssrsrq == CellInfo.UNAVAILABLE) {
+            return;
+        }
+        this.ssrsrq = ssrsrq;
+    }
+
+    public Integer getSssinr() {
+        return sssinr;
+    }
+
+    public void setSssinr(Integer sssinr) {
+        if (sssinr == null || sssinr == CellInfo.UNAVAILABLE) {
+            return;
+        }
+        this.sssinr = sssinr;
+    }
+
+    public Integer getDummyMeasurement() {
+        return dummyMeasurement;
+    }
+
+    public void setDummyMeasurement(Integer dummy) {
+        this.dummyMeasurement = dummy;
+    }
+
+    public void setCellType(int newType) { this.cellType = newType; }
+
+    public int getCellType() { return cellType; }
+}

--- a/app/src/main/java/cloudcity/networking/models/Iperf3NetworkDataModel.java
+++ b/app/src/main/java/cloudcity/networking/models/Iperf3NetworkDataModel.java
@@ -17,7 +17,7 @@ public class Iperf3NetworkDataModel extends NetworkDataModel {
     @SerializedName("speed")
     private double speed;
     @SerializedName("cell_info")
-    private final CellInfoModel cellData;
+    private final ExtendedCellInfoModel cellData;
 
     public Iperf3NetworkDataModel(
             @NonNull Iperf3MetricsPOJO.UploadMetrics upload,
@@ -31,11 +31,14 @@ public class Iperf3NetworkDataModel extends NetworkDataModel {
         super(
                 location.getLatitude(),
                 location.getLongitude(),
-                new Iperf3ValuesModel(upload, download, rttMetrics, packageLossMetrics, measurementsModel)
+                new Iperf3ValuesModel(upload, download, rttMetrics, packageLossMetrics)
         );
         this.accuracy = location.getAccuracy();
         this.speed = location.getSpeed();
-        this.cellData = cellInfoModel;
+        // Create the ExtendedCellInfo by merging the cellInfoModel with measurementsModel
+        // we do this because we don't want actual signal measurements in the iperf3 values
+        // but could use them in the cell_info
+        this.cellData = new ExtendedCellInfoModel(measurementsModel, cellInfoModel);
     }
 }
 
@@ -85,27 +88,10 @@ class Iperf3ValuesModel extends NetworkDataModel.NetworkDataModelValues {
     @SerializedName("ping_package_loss_last")
     private final double PLlast;
 
-    @SerializedName("cell_type")
-    private final int cellType;
-
-    // LTE
-    private final Integer rsrp;
-    private final Integer rsrq;
-    private final Integer rssnr;
-
-    // 5G
-    private final Integer csirsrp;
-    private final Integer csirsrq;
-    private final Integer csisinr;
-    private final Integer ssrsrp;
-    private final Integer ssrsrq;
-    private final Integer sssinr;
-
     public Iperf3ValuesModel(@NonNull Iperf3MetricsPOJO.UploadMetrics upload,
                              @NonNull Iperf3MetricsPOJO.DownloadMetrics download,
                              @NonNull PingMetricsPOJO.RTTMetrics rttMetrics,
-                             @NonNull PingMetricsPOJO.PackageLossMetrics packageLossMetrics,
-                             @NonNull MeasurementsModel cellMeasurements) {
+                             @NonNull PingMetricsPOJO.PackageLossMetrics packageLossMetrics) {
         ULmin = upload.getULmin();
         ULmedian = upload.getULmedian();
         ULmean = upload.getULmean();
@@ -129,18 +115,5 @@ class Iperf3ValuesModel extends NetworkDataModel.NetworkDataModelValues {
         PLmean = packageLossMetrics.getPLmean();
         PLmax = packageLossMetrics.getPLmax();
         PLlast = packageLossMetrics.getPLlast();
-
-        rsrp = cellMeasurements.getRsrp();
-        rsrq = cellMeasurements.getRsrq();
-        rssnr = cellMeasurements.getRssnr();
-
-        csirsrp = cellMeasurements.getCsirsrp();
-        csirsrq = cellMeasurements.getCsirsrq();
-        csisinr = cellMeasurements.getCsisinr();
-        ssrsrp = cellMeasurements.getSsrsrp();
-        ssrsrq = cellMeasurements.getSsrsrq();
-        sssinr = cellMeasurements.getSssinr();
-
-        cellType = cellMeasurements.getCellType();
     }
 }


### PR DESCRIPTION
The previous payload was 'bad' because the following things were being sent under iperf3 values:

```
                "cell_type": 4,
                "rsrp": -107,
                "rsrq": -17,
                "rssnr": -1
```

Actually, all "signal info" was being sent depending on what cell we're registered on, but that's besides the point. This was due to the initial misunderstanding of what "cell info" actually is, but after implementing that part properly i just didn't remove these values from the iperf3 values.

Now, they are no longer part of the iperf3 values (as they're also being sent as part of another API payload) *but* we have moved them to the cell_info portion of the payload, so they can signify under what conditions the iperf3 test was executed under.

Thus, the new iperf3 API payload will contain the signal info (previously contained in 'values') in the 'cell_info' portion of the JSON, and keep the 'values' with just iperf3 measured values.

Something like this:
```
{
    "sensor_events": [
        {
            "accuracy": 13.89799976348877,
            "category": "Iperf3",
            "cell_info": {
                "cellId": 440,
                "cell_type": 4,
                "pci": 280,
                "rsrp": -106,
                "rsrq": -19,
                "rssnr": -1
            },
            "speed": 0,
            "lat": 44.7483276,
            "lon": 20.4258972,
            "values": {
                "download_last": 5.24156970255062,
                "download_max": 5.24156970255062,
                "download_mean": 3.8498429249998973,
                "download_median": 4.193507151416855,
                "download_min": 2.097791820143203,
                "ping_package_loss_last": 0,
                "ping_package_loss_max": 0,
                "ping_package_loss_mean": 0,
                "ping_package_loss_median": 0,
                "ping_package_loss_min": 0,
                "ping_RTT_last": 63.1,
                "ping_RTT_max": 45.96,
                "ping_RTT_mean": 63.1,
                "ping_RTT_median": 42.4,
                "ping_RTT_min": 38,
                "upload_last": 15.73576822905426,
                "upload_max": 15.73576822905426,
                "upload_mean": 8.800838381352749,
                "upload_median": 9.43533486239412,
                "upload_min": 0
            }
        }
    ]
}
```