### PR TITLE
Iperf3 "running status" Repository

### DIFF
--- a/app/src/main/java/cloudcity/CloudCityOMNTApplication.java
+++ b/app/src/main/java/cloudcity/CloudCityOMNTApplication.java
@@ -22,6 +22,7 @@ public class CloudCityOMNTApplication extends Application {
 
         Timber.plant(new Timber.DebugTree());
 
+        Iperf3StatusRepository.initialize();
         Iperf3Monitor.initialize(getApplicationContext());
         iperf3Monitor = Iperf3Monitor.getInstance();
 

--- a/app/src/main/java/cloudcity/Iperf3StatusRepository.java
+++ b/app/src/main/java/cloudcity/Iperf3StatusRepository.java
@@ -1,0 +1,76 @@
+package cloudcity;
+
+import android.content.Context;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class Iperf3StatusRepository {
+
+    private static volatile Iperf3StatusRepository instance;
+    private volatile AtomicBoolean runningStatus;
+
+    private Iperf3StatusRepository() {
+        runningStatus = new AtomicBoolean(false);
+    }
+
+    /**
+     * Initializes the repository, loads saved data and prefills it with data if no data was found
+     *
+     * @param ctx the context to use
+     */
+    public static void initialize() {
+        if (instance != null) {
+            throw new IllegalStateException("Already initialized!");
+        } else {
+            // Since instance is null, this branch is already the first part of
+            // the double-locked synchronized singleton creation
+            synchronized (Iperf3StatusRepository.class) {
+                if (instance == null) {
+                    instance = new Iperf3StatusRepository();
+                }
+            }
+        }
+    }
+
+    public static Iperf3StatusRepository getInstance() {
+        if (instance == null) {
+            throw new IllegalStateException("Must call initialize() first!");
+        }
+
+        return instance;
+    }
+
+    /**
+     * Sets runningStatus to true if it's currently false and returns true if that was the case. Throws otherwise
+     * @return true of throws if expected value (false) didn't match the current value
+     */
+    public boolean startRunning() {
+        boolean actualStatus = runningStatus.compareAndSet(false, true);
+        if (actualStatus) {
+            return true;
+        } else {
+            throw new IllegalStateException("Actually failed to compareAndSet runningStatus! actualValue (" + actualStatus + ") was not equal to (false) before setting to (true)!");
+        }
+    }
+
+    /**
+     * Sets runningStatus to false if it's currently true and returns true if that was the case. Throws otherwise
+     * @return true or throws if expected value (true) didn't match the current value
+     */
+    public boolean stopRunning() {
+        boolean actualStatus = runningStatus.compareAndSet(true, false);
+        if (actualStatus) {
+            return true;
+        } else {
+            throw new IllegalStateException("Actually failed to compareAndSet runningStatus! actualValue (" + actualStatus + ") was not equal to (true) before setting to (false)!");
+        }
+    }
+
+    /**
+     * Returns the current running status
+     * @return the current state of runningStatus
+     */
+    public synchronized boolean getRunningStatus() {
+        return runningStatus.get();
+    }
+}


### PR DESCRIPTION
Since I suspected that something is going very wrong with synchronization, I made a centralized "is iperf3 test running" repository to be easily queried before the Iperf3Monitor.startDefault15SecTest() is even called.

I did that because I notice *a lot* of tests "running" in the iperf3->instances screen, as if a new test was started **exactly** every 5 seconds, which should be impossible given the current synchronization locks in place. But yet, the screen was completely misleading me there as well.

It turns out, that the real culprit of why iperf3 isn't running on PROD is because pinging isn't enabled for it, and that right after the pingtest starts - and never finishes successfully to let the listener know - it plants in fake data into the middle-man databases used to convey data between the WM Workers running the native libs and the rest of the app.

So, iperf3 test never really ever starts, pingtest never really ever finishes successfuly, fake planted data tells us that the test is "still running", all of the code still remains somewhat "locked in", waiting for the test to finish, and planted data keeps misleading us that iperf3 tests, which are still ongoing, have been started **exactly** every 5 seconds.

This repository and PR shouldn't be needed, but helped pinpoint the exact problem more easily.