### PR TITLE
Fix actual production issue with not sending iperf3 results to PROD environment

### DIFF
--- a/app/src/main/java/cloudcity/PingMonitor.java
+++ b/app/src/main/java/cloudcity/PingMonitor.java
@@ -35,7 +35,7 @@ import de.fraunhofer.fokus.OpenMobileNetworkToolkit.Ping.PingWorker;
 public class PingMonitor {
     private static final String TAG = "PingMonitor";
 
-    private static volatile String DEFAULT_PING_ADDRESS = CloudCityParamsRepository.getInstance().getServerUrl();
+    private static volatile String DEFAULT_PING_ADDRESS = CloudCityConstants.CLOUD_CITY_IPERF3_SERVER;
 
     private final static int DEFAULT_PING_PACKET_COUNT = 5;
 


### PR DESCRIPTION
This PR solves two issues:

1) the ping test should have pinged the iPerf3 server, not our actual API server 
2) the initial "test is running" data was fakely planted regardless of whether the iperf3 test was actually started or not, which caused a certain mixup with thinking that **many more** iperf3 tests were started (and are running) than actually are/were.

As tested, both STAGING and PROD environments now correctly ping the iperf3 server before starting the iperf3 test targeting the iperf3 server.

The API will still correctly upload data to the API server, and both environments correctly return 201 now, and there's no more misleading "iperf3 test is started every 5 seconds" as can be observed from the iperf3->instances screen when in fact, no such tests ever happened.

It just "used to work fine" since I was always testing on staging, which was used for iperf3 tests as well, so the pingtest was always targetting what it could hit. My bad.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced monitoring capabilities for Iperf3 tests, ensuring accurate database updates post-test initiation.
	- Set a fixed server address for ping tests, improving consistency in monitoring.

- **Bug Fixes**
	- Improved clarity and efficiency in the observation logic for Iperf3 test results.

- **Refactor**
	- Streamlined the observer registration mechanism for Iperf3 tests.

- **Style**
	- Minor adjustments made to logging statements for better traceability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->